### PR TITLE
Keyset cache implementation

### DIFF
--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoAutoConfiguration.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoAutoConfiguration.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.NoOpCache;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -31,10 +33,15 @@ public class CryptoAutoConfiguration {
 	}
 
 	@Bean
-	KeysetStore repositoryKeysetStore(KeysetRepository repository, ObjectProvider<KeysetFactory> factories,
-			ObjectProvider<KeyEncryptionKeyProvider> providers) {
-		return new RepostoryKeysetStore(repository, factories.orderedStream().toList(),
-				providers.orderedStream().toList());
+	KeysetStore repositoryKeysetStore(KeysetRepository repository, ObjectProvider<KeysetCache> cache,
+			ObjectProvider<KeysetFactory> factories, ObjectProvider<KeyEncryptionKeyProvider> providers) {
+		return new RepostoryKeysetStore(cache.getIfAvailable(CryptoAutoConfiguration::createNoopKeysetCache),
+				repository, factories.orderedStream().toList(), providers.orderedStream().toList());
+	}
+
+	private static KeysetCache createNoopKeysetCache() {
+		final Cache delegate = new NoOpCache("noop-keyset-cache");
+		return new SpringKeysetCache(delegate);
 	}
 
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoException.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoException.java
@@ -298,6 +298,13 @@ public abstract class CryptoException extends RuntimeException {
 
 	}
 
+	/**
+	 * Exception thrown when the {@link Keyset} is being encrypted, or wrapped, by the
+	 * responsible {@link KeyEncryptionKey}.
+	 * <p>
+	 * This exception contains both the name of {@link Keyset} and the actual
+	 * {@link KeyEncryptionKey} values for which this exception has been thrown.
+	 */
 	@Getter
 	public static class WrappingException extends KeysetException {
 
@@ -318,6 +325,13 @@ public abstract class CryptoException extends RuntimeException {
 
 	}
 
+	/**
+	 * Exception thrown when the {@link EncryptedKeyset} is being decrypted, or unwrapped,
+	 * by the responsible {@link KeyEncryptionKey}.
+	 * <p>
+	 * This exception contains both the name of {@link EncryptedKeyset} and the actual
+	 * {@link KeyEncryptionKey} values for which this exception has been thrown.
+	 */
 	@Getter
 	public static class UnwrappingException extends KeysetException {
 

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetCache.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetCache.java
@@ -1,0 +1,46 @@
+package com.konfigyr.crypto;
+
+import org.springframework.lang.NonNull;
+
+import java.util.function.Supplier;
+
+/**
+ * Interface that defines how encrypted cryptographic material is cached.
+ *
+ * @author : Vladimir Spasic
+ * @since : 06.09.23, Wed
+ **/
+public interface KeysetCache {
+
+	/**
+	 * Retrieves the {@link EncryptedKeyset} with the specified cached key, obtaining that
+	 * value from {@link Supplier} if it is not present.
+	 * <p>
+	 * If possible, implementations of this method should ensure that the loading
+	 * operation is synchronized so that the specified supplying function is only called
+	 * once in case of concurrent access on the same key.
+	 * @param key the key for which the {@link EncryptedKeyset} is to be returned, can't
+	 * be {@literal null}
+	 * @param supplier function that would obtain the value if the cached value is not
+	 * present in the cache, can't be {@literal null}
+	 * @return cached encrypted keyset, never {@literal null}
+	 */
+	EncryptedKeyset get(@NonNull String key, @NonNull Supplier<EncryptedKeyset> supplier);
+
+	/**
+	 * Stores the {@link EncryptedKeyset} value with the specified key in this cache.
+	 * @param key the key for which the {@link EncryptedKeyset} is to be associated, can't
+	 * be {@literal null}
+	 * @param keyset the {@link EncryptedKeyset} value to be associated with the specified
+	 * key
+	 */
+	void put(@NonNull String key, @NonNull EncryptedKeyset keyset);
+
+	/**
+	 * Evicts the {@link EncryptedKeyset} for this key from this cache if it is present.
+	 * @param key the key for which the {@link EncryptedKeyset} is to be evicted, can't be
+	 * {@literal null}
+	 */
+	void evict(@NonNull String key);
+
+}

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetStore.java
@@ -109,6 +109,7 @@ public interface KeysetStore {
 	 * can't be {@literal null}.
 	 * @param definition definition to be used when creating a new keyset, can't be
 	 * {@literal null}.
+	 * @return the generate {@link Keyset}, never {@literal null}
 	 * @throws com.konfigyr.crypto.CryptoException.ProviderNotFoundException when provider
 	 * with a given name does not exist
 	 * @throws com.konfigyr.crypto.CryptoException.KeyEncryptionKeyNotFoundException when
@@ -133,6 +134,7 @@ public interface KeysetStore {
 	 * can't be {@literal null}.
 	 * @param definition definition to be used when creating a new keyset, can't be
 	 * {@literal null}.
+	 * @return the generate {@link Keyset}, never {@literal null}
 	 * @throws com.konfigyr.crypto.CryptoException.ProviderNotFoundException when provider
 	 * with a given name does not exist
 	 * @throws com.konfigyr.crypto.CryptoException.KeyEncryptionKeyNotFoundException when

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepostoryKeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepostoryKeysetStore.java
@@ -3,7 +3,6 @@ package com.konfigyr.crypto;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cache.Cache;
 import org.springframework.lang.NonNull;
 
 import java.io.IOException;

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SpringKeysetCache.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SpringKeysetCache.java
@@ -1,0 +1,51 @@
+package com.konfigyr.crypto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.lang.NonNull;
+
+import java.util.function.Supplier;
+
+/**
+ * Implementation of the {@link KeysetCache} that uses Spring {@link Cache} implementation
+ * as the actual cache store.
+ *
+ * @author : Vladimir Spasic
+ * @since : 06.09.23, Wed
+ **/
+@RequiredArgsConstructor
+public class SpringKeysetCache implements KeysetCache {
+
+	private final Cache cache;
+
+	@Override
+	public synchronized EncryptedKeyset get(@NonNull String key, @NonNull Supplier<EncryptedKeyset> supplier) {
+		EncryptedKeyset encryptedKeyset = cache.get(key, EncryptedKeyset.class);
+
+		if (encryptedKeyset != null) {
+			return encryptedKeyset;
+		}
+
+		encryptedKeyset = supplier.get();
+
+		if (encryptedKeyset == null) {
+			throw new IllegalStateException("Keyset cache detected a null encrypted keyset value for " + "cache key '"
+					+ key + "'. This is currently not supported by this cache implementation.");
+		}
+
+		put(key, encryptedKeyset);
+
+		return encryptedKeyset;
+	}
+
+	@Override
+	public synchronized void put(@NonNull String key, @NonNull EncryptedKeyset keyset) {
+		cache.put(key, keyset);
+	}
+
+	@Override
+	public synchronized void evict(@NonNull String key) {
+		cache.evict(key);
+	}
+
+}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/SpringKeysetCacheTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/SpringKeysetCacheTest.java
@@ -1,0 +1,85 @@
+package com.konfigyr.crypto;
+
+import com.konfigyr.io.ByteArray;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+import java.time.Instant;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SpringKeysetCacheTest {
+
+	@Spy
+	Cache delegate = new ConcurrentMapCache("test-cache");
+
+	@Mock
+	Supplier<EncryptedKeyset> supplier;
+
+	KeysetCache cache;
+
+	@BeforeEach
+	void setup() {
+		cache = new SpringKeysetCache(delegate);
+	}
+
+	@Test
+	void shouldRetrieveCachedKeysets() {
+		final var keyset = createEncryptedKeyset("test-keyset");
+		doReturn(keyset).when(supplier).get();
+
+		assertThat(cache.get(keyset.getName(), supplier)).isEqualTo(keyset);
+		assertThat(cache.get(keyset.getName(), supplier)).isEqualTo(keyset);
+
+		verify(supplier).get();
+		verify(delegate, times(2)).get(eq(keyset.getName()), eq(EncryptedKeyset.class));
+	}
+
+	@Test
+	void shouldStoreKeysetInCacheAndEvict() {
+		final var keyset = createEncryptedKeyset("testing-keyset");
+
+		assertThatNoException().isThrownBy(() -> cache.put("cache-key", keyset));
+		assertThat(cache.get("cache-key", supplier)).isEqualTo(keyset);
+		assertThatNoException().isThrownBy(() -> cache.evict("cache-key"));
+
+		verifyNoInteractions(supplier);
+		verify(delegate).get(eq("cache-key"), eq(EncryptedKeyset.class));
+		verify(delegate).put(eq("cache-key"), eq(keyset));
+		verify(delegate).evict(eq("cache-key"));
+
+		assertThat(delegate.get("cache-key")).isNull();
+	}
+
+	@Test
+	void shouldNotStoreNullKeysets() {
+		assertThatThrownBy(() -> cache.get("cache-key", supplier)).isInstanceOf(IllegalStateException.class)
+			.hasNoCause()
+			.hasMessageContaining("Keyset cache detected a null encrypted keyset value for cache key 'cache-key'");
+
+		verify(supplier).get();
+		verify(delegate).get(eq("cache-key"), eq(EncryptedKeyset.class));
+	}
+
+	private static EncryptedKeyset createEncryptedKeyset(String name) {
+		return EncryptedKeyset.builder()
+			.name(name)
+			.algorithm("test-algorithm")
+			.provider("test-provider")
+			.keyEncryptionKey("test-kek")
+			.rotationInterval(60)
+			.nextRotationTime(Instant.now())
+			.build(ByteArray.fromString("encrypted material for " + name));
+	}
+
+}

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeyEncryptionKey.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeyEncryptionKey.java
@@ -63,7 +63,14 @@ public class TinkKeyEncryptionKey extends AbstractKeyEncryptionKey {
 		}
 	}
 
-	public static Builder builder(String provider) {
+	/**
+	 * Creates a new {@link Builder Tink KEK Builder} instance with the name of the
+	 * {@link com.konfigyr.crypto.KeyEncryptionKeyProvider} that would own the
+	 * {@link KeyEncryptionKey} that is being built.
+	 * @param provider name of the {@link com.konfigyr.crypto.KeyEncryptionKeyProvider}.
+	 * @return Tink KEK builder, never {@literal null}
+	 */
+	public static @NonNull Builder builder(String provider) {
 		Assert.hasText(provider, "Key Encryption Key provider name can not be blank");
 		return new Builder(provider);
 	}


### PR DESCRIPTION
Introduction of `KeysetCache` interface that defines an API to cache `EncryptedKeyset` values. Default implementation of this API is based on Spring `Cache`.