### PR TITLE
Byte array improvements

### DIFF
--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/io/ByteArray.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/io/ByteArray.java
@@ -28,7 +28,7 @@ import java.util.Base64;
  * @since : 01.09.22, Thu
  **/
 @NullMarked
-public record ByteArray(byte[] array) implements InputStreamSource, Serializable {
+public final class ByteArray implements InputStreamSource, Serializable {
 
 	@Serial
 	private static final long serialVersionUID = 3838515107166328896L;
@@ -36,12 +36,48 @@ public record ByteArray(byte[] array) implements InputStreamSource, Serializable
 	private static final ByteArray EMPTY = new ByteArray(new byte[0]);
 
 	/**
+	 * The implementation of the {@link Encoder} that uses {@link Base64.Encoder} to encode the byte array.
+	 */
+	static final Encoder BASE_64_ENCODER = Base64.getEncoder()::encodeToString;
+
+	/**
+	 * The implementation of the {@link Decoder} that uses {@link Base64.Decoder} to decode the byte array.
+	 */
+	static final Decoder BASE_64_DECODER = Base64.getDecoder()::decode;
+
+	/**
+	 * The implementation of the {@link Encoder} that uses URL Safe variant of the {@link Base64.Encoder} to
+	 * encode the value to a byte array.
+	 */
+	static final Encoder BASE_64_URL_SAFE_ENCODER = Base64.getUrlEncoder()::encodeToString;
+
+	/**
+	 * The implementation of the {@link Decoder} that uses URL Safe variant of the {@link Base64.Decoder} to
+	 * decode the value to a byte array.
+	 */
+	static final Decoder BASE_64_URL_SAFE_DECODER = Base64.getUrlDecoder()::decode;
+
+	/**
+	 * The underlying byte array that contains the actual data.
+	 */
+	private final byte[] array;
+
+	/**
 	 * Creates a new {@link ByteArray} by copying the data from the given array of bytes.
 	 *
 	 * @param array byte array data
 	 */
 	public ByteArray(byte[] array) {
-		this.array = Arrays.copyOf(array, array.length);
+		this(array, 0, array.length);
+	}
+
+	/**
+	 * Creates a new {@link ByteArray} by copying the data from the given array of bytes.
+	 *
+	 * @param array byte array data
+	 */
+	private ByteArray(byte[] array, int offset, int length) {
+		this.array = Arrays.copyOfRange(array, offset, offset + length);
 	}
 
 	/**
@@ -77,6 +113,30 @@ public record ByteArray(byte[] array) implements InputStreamSource, Serializable
 	}
 
 	/**
+	 * Creates a new {@link ByteArray} instance from the given byte array over a slice of a Bytes.
+	 *
+	 * @param bytes bytes to be wrapped and sliced, can't be {@literal null}
+	 * @param start the starting index of the slice
+	 * @param length the length of the slice. If start + len is larger than the size of {@code bytes}, the
+	 *               remaining data will be returned.
+	 * @return byte array in the slice from {@code start} to {@code start + length}, never {@literal null}
+	 */
+	public static ByteArray from(byte[] bytes, int start, int length) {
+		return new ByteArray(bytes, start, length);
+	}
+
+	/**
+	 * Creates a new {@link ByteArray} instance from the given string and the given {@link Decoder}.
+	 *
+	 * @param data raw string to be decoded and wrapped as a byte array, can't be {@literal null}
+	 * @param decoder decoder to use for decoding the string, can't be {@literal null}
+	 * @return byte array, never {@literal null}
+	 */
+	public static ByteArray decode(String data, Decoder decoder) {
+		return new ByteArray(decoder.decode(data));
+	}
+
+	/**
 	 * Creates a new {@link ByteArray} instance from the given string. The string is converted to bytes using
 	 * the {@link StandardCharsets#UTF_8} charset.
 	 *
@@ -100,14 +160,25 @@ public record ByteArray(byte[] array) implements InputStreamSource, Serializable
 	}
 
 	/**
-	 * Creates a new {@link ByteArray} instance from the given Base64 URL Safe encoded string.
+	 * Creates a new {@link ByteArray} instance from the given Base64 encoded string.
 	 *
 	 * @return byte array, never {@literal null}
 	 * @param data Base64 encoded string to be wrapped, can't be {@literal null}
 	 * @throws IllegalArgumentException when the Base64 string is invalid
 	 */
 	public static ByteArray fromBase64String(String data) {
-		return new ByteArray(Base64.getUrlDecoder().decode(data));
+		return decode(data, BASE_64_DECODER);
+	}
+
+	/**
+	 * Creates a new {@link ByteArray} instance from the given Base64 URL safe encoded string.
+	 *
+	 * @return byte array, never {@literal null}
+	 * @param data Base64 URL safe encoded string to be wrapped, can't be {@literal null}
+	 * @throws IllegalArgumentException when the Base64 string is invalid
+	 */
+	public static ByteArray fromBase64UrlString(String data) {
+		return decode(data, BASE_64_URL_SAFE_DECODER);
 	}
 
 	/**
@@ -125,18 +196,38 @@ public record ByteArray(byte[] array) implements InputStreamSource, Serializable
 	}
 
 	/**
+	 * Encodes the contents of this byte array into a Base64 string.
+	 *
+	 * @return Base64 encoded string, never {@literal null}.
+	 */
+	public String encodeBase64() {
+		return encode(BASE_64_ENCODER);
+	}
+
+	/**
 	 * Encodes the contents of this byte array into a Base64 URL Safe string.
 	 *
 	 * @return Base64 URL encoded string, never {@literal null}.
 	 */
-	public String encode() {
-		return Base64.getUrlEncoder().encodeToString(array);
+	public String encodeBase64Url() {
+		return encode(BASE_64_URL_SAFE_ENCODER);
 	}
 
 	/**
-	 * Checks if the underlying byte array contents are empty. This is performed by checking the size of the contents.
+	 * Encodes the contents of this byte array using the given encoder.
 	 *
-	 * @return {@code true} if the array empty, {@code false} otherwise.
+	 * @param encoder encoder to use for encoding the byte array, can't be {@literal null}.
+	 * @return encoded string, never {@literal null}.
+	 */
+	public String encode(Encoder encoder) {
+		return encoder.encode(array);
+	}
+
+	/**
+	 * Checks if the underlying byte array contents are empty. This is performed by checking the size
+	 * of the contents.
+	 *
+	 * @return {@code true} if the array is empty, {@code false} otherwise.
 	 */
 	public boolean isEmpty() {
 		return array.length == 0;
@@ -167,5 +258,37 @@ public record ByteArray(byte[] array) implements InputStreamSource, Serializable
 	@Override
 	public String toString() {
 		return "ByteArray[" + size() + "]";
+	}
+
+	/**
+	 * Interface used to encode the byte array into a string.
+	 */
+	@FunctionalInterface
+	public interface Encoder {
+
+		/**
+		 * Encodes the given byte array into a string.
+		 *
+		 * @param bytes the bytes to encode, can't be {@literal null}
+		 * @return the encoded string, never {@literal null}
+		 */
+		String encode(byte[] bytes);
+
+	}
+
+	/**
+	 * Interface used to decode the string into a byte array.
+	 */
+	@FunctionalInterface
+	public interface Decoder {
+
+		/**
+		 * Decodes the given string into a byte array.
+		 *
+		 * @param string the string to decode, can't be {@literal null}
+		 * @return the decoded byte array, never {@literal null}
+		 */
+		byte[] decode(String string);
+
 	}
 }

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/io/ByteArrayTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/io/ByteArrayTest.java
@@ -1,6 +1,7 @@
 package com.konfigyr.io;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 
@@ -18,9 +19,8 @@ class ByteArrayTest {
 
 	private final static String TEST_ORIGINAL = "testing string";
 
-	private final static String TEST_ENCODED = "dGVzdGluZyBiYXNlNjQ=";
-
 	@Test
+	@DisplayName("should create immutable byte array instances by copying the data from the original byte array")
 	void shouldCreateImmutableByteArrays() {
 		var data = TEST_ORIGINAL.getBytes();
 
@@ -36,11 +36,67 @@ class ByteArrayTest {
 	}
 
 	@Test
+	@DisplayName("should create immutable byte array instances by copying the data slice")
+	void shouldCreateImmutableByteArraySlices() {
+		var data = new byte[] { 1, 2, 3, 4, 5, 6 };
+
+		final var array = ByteArray.from(data, 2, 2);
+		assertThat(array.array()).isEqualTo(new byte[] { 3, 4 });
+
+		data[3] = 6;
+		assertThat(array.array()).isEqualTo(new byte[] { 3, 4 });
+
+		data = array.array();
+		data[1] = 8;
+		assertThat(array.array()).isNotEqualTo(data);
+	}
+
+	@Test
+	@DisplayName("should create a byte array using the Base64 decoder function and test encoding")
+	void shouldDecodeAndEncodeBase64() {
+		final var data = "c3ViamVjdHM/ID4gMTA=";
+		final var array = ByteArray.decode(data, ByteArray.BASE_64_DECODER);
+
+		assertThat(array)
+			.isNotNull()
+			.isEqualTo(ByteArray.fromBase64String(data));
+
+		assertThat(array.encodeBase64())
+			.isEqualTo(array.encode(ByteArray.BASE_64_ENCODER))
+			.isEqualTo(data);
+
+		assertThat(array.encodeBase64Url())
+			.isNotEqualTo(array.encode(ByteArray.BASE_64_ENCODER))
+			.isNotEqualTo(data);
+	}
+
+	@Test
+	@DisplayName("should create a byte array using the Base64 URL safe decoder function and test encoding")
+	void shouldDecodeAndEncodeBase64UrlSafe() {
+		final var data = "c3ViamVjdHM_ID4gMTA=";
+		final var array = ByteArray.decode(data, ByteArray.BASE_64_URL_SAFE_DECODER);
+
+		assertThat(array)
+			.isNotNull()
+			.isEqualTo(ByteArray.fromBase64UrlString(data));
+
+		assertThat(array.encodeBase64Url())
+			.isEqualTo(array.encode(ByteArray.BASE_64_URL_SAFE_ENCODER))
+			.isEqualTo(data);
+
+		assertThat(array.encodeBase64())
+			.isNotEqualTo(array.encode(ByteArray.BASE_64_URL_SAFE_ENCODER))
+			.isNotEqualTo(data);
+	}
+
+	@Test
+	@DisplayName("should create an input stream from data stored in the byte array")
 	void shouldCreateInputStream() {
 		final var array = ByteArray.fromString(TEST_ORIGINAL);
 
-		assertThat(array).isNotNull()
-			.extracting("inputStream")
+		assertThat(array)
+			.isNotNull()
+			.extracting(ByteArray::getInputStream)
 			.isNotNull()
 			.isInstanceOf(ByteArrayInputStream.class)
 			.asInstanceOf(InstanceOfAssertFactories.type(ByteArrayInputStream.class))
@@ -49,96 +105,96 @@ class ByteArrayTest {
 	}
 
 	@Test
+	@DisplayName("should create a byte array from a byte buffer")
 	void shouldCreateByteArrayFromByteBuffer() {
-		final var array = ByteArray.from(ByteBuffer.wrap(TEST_ORIGINAL.getBytes(StandardCharsets.UTF_8)));
+		final var data = ByteBuffer.wrap(TEST_ORIGINAL.getBytes(StandardCharsets.UTF_8));
+		final var array = ByteArray.from(data);
 
-		assertThat(array).isNotNull()
-			.isEqualTo(ByteArray.fromString(TEST_ORIGINAL))
-			.isEqualTo(ByteArray.fromBase64String("dGVzdGluZyBzdHJpbmc="))
-			.isNotEqualTo(ByteArray.fromString(TEST_ORIGINAL, StandardCharsets.UTF_16))
+		assertThat(array)
+			.isNotNull()
+			.returns(data.array(), ByteArray::array)
 			.returns(false, ByteArray::isEmpty)
 			.returns(14, ByteArray::size)
-			.returns("dGVzdGluZyBzdHJpbmc=", ByteArray::encode)
-			.returns(TEST_ORIGINAL, it -> new String(it.array()))
-			.extracting(ByteArray::array)
-			.isEqualTo(array.array());
+			.returns(TEST_ORIGINAL, it -> array.encode(String::new));
 	}
 
 	@Test
+	@DisplayName("should create a byte array from a data buffer")
 	void shouldCreateByteArrayFromDataBuffer() {
-		final var array = ByteArray
-			.from(DefaultDataBufferFactory.sharedInstance.wrap(TEST_ORIGINAL.getBytes(StandardCharsets.UTF_8)));
+		final var data = DefaultDataBufferFactory.sharedInstance
+			.wrap(TEST_ORIGINAL.getBytes(StandardCharsets.UTF_8));
 
-		assertThat(array).isNotNull()
-			.isEqualTo(ByteArray.fromString(TEST_ORIGINAL))
-			.isEqualTo(ByteArray.fromBase64String("dGVzdGluZyBzdHJpbmc="))
-			.isNotEqualTo(ByteArray.fromString(TEST_ORIGINAL, StandardCharsets.UTF_16))
+		final var array = ByteArray.from(data);
+
+		assertThat(array)
+			.isNotNull()
+			.returns(data.getNativeBuffer().array(), ByteArray::array)
 			.returns(false, ByteArray::isEmpty)
 			.returns(14, ByteArray::size)
-			.returns("dGVzdGluZyBzdHJpbmc=", ByteArray::encode)
-			.returns(TEST_ORIGINAL, it -> new String(it.array()))
-			.extracting(ByteArray::array)
-			.isEqualTo(array.array());
+			.returns(TEST_ORIGINAL, it -> array.encode(String::new));
 	}
 
 	@Test
+	@DisplayName("should create a byte array from a string and default charset")
 	void shouldCreateByteArrayFromString() {
 		final var array = ByteArray.fromString(TEST_ORIGINAL);
 
-		assertThat(array).isNotNull()
-			.isEqualTo(ByteArray.fromString(TEST_ORIGINAL))
-			.isEqualTo(ByteArray.fromBase64String("dGVzdGluZyBzdHJpbmc="))
-			.isNotEqualTo(ByteArray.fromString(TEST_ORIGINAL, StandardCharsets.UTF_16))
+		assertThat(array)
+			.isNotNull()
+			.returns(TEST_ORIGINAL.getBytes(), ByteArray::array)
 			.returns(false, ByteArray::isEmpty)
 			.returns(14, ByteArray::size)
-			.returns("dGVzdGluZyBzdHJpbmc=", ByteArray::encode)
-			.returns(TEST_ORIGINAL, it -> new String(it.array()))
-			.extracting(ByteArray::array)
-			.isEqualTo(array.array());
+			.returns(TEST_ORIGINAL, it -> array.encode(String::new));
 	}
 
 	@Test
+	@DisplayName("should create a byte array from a string and specified charset")
 	void shouldCreateByteArrayFromStringAndSpecifiedCharset() {
 		final var array = ByteArray.fromString(TEST_ORIGINAL, StandardCharsets.UTF_16);
 
-		assertThat(array).isNotNull()
-			.isEqualTo(ByteArray.fromString(TEST_ORIGINAL, StandardCharsets.UTF_16))
-			.isEqualTo(ByteArray.fromBase64String("_v8AdABlAHMAdABpAG4AZwAgAHMAdAByAGkAbgBn"))
-			.isNotEqualTo(ByteArray.fromString(TEST_ORIGINAL, StandardCharsets.US_ASCII))
+		assertThat(array)
+			.isNotNull()
+			.returns(TEST_ORIGINAL.getBytes(StandardCharsets.UTF_16), ByteArray::array)
 			.returns(false, ByteArray::isEmpty)
 			.returns(30, ByteArray::size)
-			.returns("_v8AdABlAHMAdABpAG4AZwAgAHMAdAByAGkAbgBn", ByteArray::encode)
-			.returns(TEST_ORIGINAL, it -> new String(it.array(), StandardCharsets.UTF_16))
-			.extracting(ByteArray::array)
-			.isEqualTo(array.array());
+			.returns(TEST_ORIGINAL, it -> array.encode(data -> new String(data, StandardCharsets.UTF_16)));
 	}
 
 	@Test
-	void shouldCreateByteArrayFromBase64String() {
-		final var array = ByteArray.fromBase64String(TEST_ENCODED);
-
-		assertThat(array).isNotNull()
-			.isEqualTo(ByteArray.fromString("testing base64"))
-			.isEqualTo(ByteArray.fromBase64String(TEST_ENCODED))
-			.isNotEqualTo(ByteArray.fromString("testing base64 invalid"))
-			.returns(false, ByteArray::isEmpty)
-			.returns(14, ByteArray::size)
-			.returns(TEST_ENCODED, ByteArray::encode)
-			.returns("testing base64", it -> new String(it.array()))
-			.extracting(ByteArray::array)
-			.isEqualTo(array.array());
-	}
-
-	@Test
+	@DisplayName("should create empty byte arrays and reuse the empty byte array singleton")
 	void emptyByteArraysShouldBeEqual() {
-		assertThat(ByteArray.empty()).isNotNull()
+		final var empty = ByteArray.empty();
+
+		assertThat(empty)
+			.isNotNull()
 			.isEqualTo(ByteArray.empty())
+			.isSameAs(ByteArray.empty())
+			.hasToString("ByteArray[0]")
 			.returns(true, ByteArray::isEmpty)
 			.returns(0, ByteArray::size)
-			.returns("", ByteArray::encode)
-			.returns("", it -> new String(it.array()))
-			.extracting(ByteArray::array)
-			.isEqualTo(new byte[0]);
+			.returns(new byte[0], ByteArray::array)
+			.returns("", it -> it.encode(String::new))
+			.returns("", it -> new String(it.array()));
+	}
+
+	@Test
+	@DisplayName("should display just the size in the string representation")
+	void stringRepresentationShouldDisplaySize() {
+		assertThat(ByteArray.fromString(TEST_ORIGINAL))
+			.hasToString("ByteArray[14]");
+	}
+
+	@Test
+	@DisplayName("should perform identity and equality checks based on the contents")
+	void shouldCheckEquality() {
+		final var foo = ByteArray.fromString("foo array");
+		final var bar = ByteArray.fromString("bar array");
+
+		assertThat(foo)
+			.isEqualTo(ByteArray.fromString("foo array"))
+			.hasSameHashCodeAs(ByteArray.fromString("foo array"))
+			.isNotEqualTo(bar)
+			.doesNotHaveSameHashCodeAs(bar);
 	}
 
 }


### PR DESCRIPTION
 - create `ByteArray` from a specific `byte[]` slice
 - Introduce `ByteArray.Encoder` type that is used to encode the enclosed bytes into strings
 - Introduce `ByteArray.Decoder` type that is used to decode strings into a an array of bytes