### PR TITLE
Introduce `AlgorithmRegistry` and refactor `Algorithm` model

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI Build](https://github.com/konfigyr/konfigyr-crypto/actions/workflows/continuous-integration.yml/badge.svg)
 [![Join the chat at https://gitter.im/konfigyr/konfigyr-crypto](https://badges.gitter.im/konfigyr/konfigyr-crypto.svg)](https://gitter.im/konfigyr/konfigyr-crypt?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Latest Release](https://img.shields.io/maven-central/v/com.konfigyr/konfigyr-crypto-api.svg?style=flat)](https://central.sonatype.com/search?q=g%3Acom.konfigyr)
-![Java 17+](https://img.shields.io/badge/java-17+-lightgray.svg)
+![Java 21+](https://img.shields.io/badge/java-21+-lightgray.svg)
 
 The Konfigyr Crypto library defines instructs how should a Spring Application perform crypto operations, generate cryptographic material and manage its lifecycle. It attempts to define an API that best describes cryptography best practices how should protect your data and protect the encryption keys that protect your data.
 
@@ -61,6 +61,38 @@ Factories should be able to:
 Konfigyr Crypto comes with the following implementations of the `KeysetFactory` which you can use:
  * [Google Tink](konfigyr-crypto-tink)
  * [Nimbus JOSE JWT](konfigyr-crypto-jose)
+
+### Algorithms
+
+An `Algorithm` is an immutable value object that declares the identity and capabilities of a cryptographic algorithm:
+
+* `name()` — a stable, unique identifier that is **persisted** alongside the `EncryptedKeyset`. It must never change once key material has been created with it.
+* `purpose()` — the `KeysetPurpose` (`SIGNING` or `ENCRYPTION`), which determines which operations the keyset supports.
+* `type()` — the `KeyType` of the underlying key material (`EC`, `RSA`, or `OCTET`).
+
+The built-in `TinkAlgorithm` and `JoseAlgorithm` constants follow a naming convention of prefixing names with the library family (`tink:` and `jose:` respectively). Use a similar stable prefix for any custom algorithms to avoid name collisions.
+
+#### AlgorithmRegistry
+
+The `AlgorithmRegistry` is a sealed catalog of all algorithms known to the application. It serves two purposes:
+
+1. **Resolution** — converts the algorithm name stored in an `EncryptedKeyset` back to the concrete `Algorithm` instance needed to decrypt it.
+2. **Algorithm confusion prevention** — only algorithms registered at startup can be resolved. An `EncryptedKeyset` referencing an unknown name will fail fast rather than attempting to use an unexpected algorithm.
+
+The registry is sealed after the Spring context finishes initialising all singletons. Any attempt to register an algorithm after that point throws `IllegalStateException`.
+
+#### AlgorithmRegistrar
+
+Algorithms are contributed to the registry via `AlgorithmRegistrar` beans. Each built-in module registers its algorithms during auto-configuration:
+
+```java
+@Bean
+AlgorithmRegistrar joseAlgorithmRegistrar() {
+    return registry -> JoseAlgorithm.DEFAULT_ALGORITHMS.forEach(registry::register);
+}
+```
+
+Declare your own `AlgorithmRegistrar` bean to add custom algorithms alongside the built-in ones.
 
 ### Key encryption keys and providers
 
@@ -142,7 +174,7 @@ class TinkExample {
         return store.create("my-kek-provider", "my-kek", KeysetDefinition.of(
                 "my-dek", // give a name to your DEK
                 TinkAlgorithm.AES256_GCM, // define the Tink algorithm to the DEK
-                Duration.of(90) // define the rotation frequency for your DEK
+                Duration.ofDays(90) // define the rotation frequency for your DEK
         ));
     }
 
@@ -152,16 +184,16 @@ class TinkExample {
         return store.create(kek, KeysetDefinition.of(
                 "my-dek", // give a name to your DEK
                 TinkAlgorithm.AES256_GCM, // define the Tink algorithm to the DEK
-                Duration.of(90) // define the rotation frequency for your DEK
+                Duration.ofDays(90) // define the rotation frequency for your DEK
         ));
     }
 
-    public Keyset rotate() {
-        return store.rotate("my-dek");
+    public void rotate() {
+        store.rotate("my-dek");
     }
 
-    public Keyset remove() {
-        return store.remove("my-dek");
+    public void remove() {
+        store.remove("my-dek");
     }
 }
 ```
@@ -172,6 +204,112 @@ Keyset repository is a simple interface which goal is to implement how should an
 
 Konfigyr Crypto comes with the following implementations of the `KeysetRepository` which you can use:
 * [JDBC](konfigyr-crypto-jdbc)
+
+## Implementing a custom crypto provider
+
+To integrate a new cryptography library or add a custom algorithm, you need three things:
+
+1. An `Algorithm` implementation that declares the algorithm's identity.
+2. A `Keyset` implementation that performs the actual cryptographic operations.
+3. A `KeysetFactory` implementation that creates `Keyset` instances from definitions and encrypted data.
+
+Wire them as Spring beans and register your algorithms via `AlgorithmRegistrar`.
+
+### Step 1: Define your algorithm
+
+```java
+public final class MyAlgorithm implements Algorithm {
+
+    public static final MyAlgorithm MY_SIGNING = new MyAlgorithm(
+        "my-lib:EC_SIGNING", KeysetPurpose.SIGNING, KeyType.EC
+    );
+
+    private final String name;
+    private final KeysetPurpose purpose;
+    private final KeyType type;
+
+    public MyAlgorithm(String name, KeysetPurpose purpose, KeyType type) {
+        this.name = name;
+        this.purpose = purpose;
+        this.type = type;
+    }
+
+    @Override public String name()           { return name; }
+    @Override public KeysetPurpose purpose() { return purpose; }
+    @Override public KeyType type()          { return type; }
+}
+```
+
+The `name` is persisted in the `EncryptedKeyset` row and used to look up the algorithm at load time. Choose a stable prefix unique to your library (e.g. `my-lib:`) and never rename an algorithm once key material has been created with it.
+
+### Step 2: Implement KeysetFactory
+
+```java
+public class MyKeysetFactory implements KeysetFactory {
+
+    private final AlgorithmRegistry registry;
+
+    public MyKeysetFactory(AlgorithmRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public boolean supports(KeysetDefinition definition) {
+        // the definition carries the Algorithm object directly
+        return definition.getAlgorithm() instanceof MyAlgorithm;
+    }
+
+    @Override
+    public boolean supports(EncryptedKeyset encryptedKeyset) {
+        // the encrypted form only carries the algorithm name string — resolve via registry
+        return registry.find(encryptedKeyset.getAlgorithm())
+            .filter(a -> a instanceof MyAlgorithm)
+            .isPresent();
+    }
+
+    @Override
+    public Keyset create(KeyEncryptionKey kek, KeysetDefinition definition) {
+        MyAlgorithm algorithm = (MyAlgorithm) definition.getAlgorithm();
+        // generate key material using your library, return a Keyset implementation
+    }
+
+    @Override
+    public EncryptedKeyset create(Keyset keyset) throws IOException {
+        ByteArray serialized = // serialize your Keyset to bytes
+        ByteArray encrypted  = keyset.getKeyEncryptionKey().wrap(serialized);
+        return EncryptedKeyset.from(keyset, encrypted);
+    }
+
+    @Override
+    public Keyset create(KeyEncryptionKey kek, EncryptedKeyset encryptedKeyset) throws IOException {
+        ByteArray decrypted  = kek.unwrap(encryptedKeyset.getData());
+        MyAlgorithm algorithm = (MyAlgorithm) registry.resolve(encryptedKeyset.getAlgorithm());
+        // deserialize decrypted bytes and return a Keyset implementation
+    }
+}
+```
+
+`supports(EncryptedKeyset)` uses `registry.find()` to resolve the stored algorithm name back to a concrete instance. `supports(KeysetDefinition)` can use `instanceof` because the definition already holds the `Algorithm` object directly.
+
+### Step 3: Register and wire as Spring beans
+
+```java
+@Configuration
+class MyLibAutoConfiguration {
+
+    @Bean
+    AlgorithmRegistrar myAlgorithmRegistrar() {
+        return registry -> registry.register(MyAlgorithm.MY_SIGNING);
+    }
+
+    @Bean
+    MyKeysetFactory myKeysetFactory(AlgorithmRegistry registry) {
+        return new MyKeysetFactory(registry);
+    }
+}
+```
+
+The `KeysetStore` auto-configuration picks up all `KeysetFactory` beans automatically. Once these beans are declared, `store.create(kek, KeysetDefinition.of("my-key", MyAlgorithm.MY_SIGNING))` will delegate to your factory without any further wiring.
 
 ## Building from Source
 Konfigyr Crypto uses a Gradle-based build system. In the instructions below, `./gradlew` is invoked from the root of the source tree and serves as a cross-platform, self-contained bootstrap mechanism for the build.

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/Algorithm.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/Algorithm.java
@@ -6,29 +6,49 @@ import java.io.Serializable;
 import java.util.Set;
 
 /**
- * Algorithm interface that defines which {@link KeysetOperation} are supported by the
- * {@link Keyset keysets}, the {@link KeyType type of private key material}.
+ * Algorithm interface that defines which {@link KeysetOperation operations} are supported
+ * by a {@link Keyset}, what {@link KeysetPurpose purpose} it serves, and the
+ * {@link KeyType type} of key material it uses.
  * <p>
- * It is recommended that the implementation of this interface are a simple {@link Enum
- * Java enumerations} for easier serialization and deserialization of the
- * {@link Algorithm} values.
+ * Implementations should be immutable value objects. Each cryptographic library module
+ * (e.g. {@code konfigyr-crypto-tink}, {@code konfigyr-crypto-jose}) provides a set of
+ * pre-built constants for the algorithms it supports.
  * <p>
- * How an {@link Algorithm} is serialized and deserialized is usually defined by the
- * {@link KeysetFactory}, as this is the interface that defines how keysets are created,
- * wrapped and unwrapped.
+ * Custom algorithms can be created by implementing this interface and registering the
+ * instance with the {@link AlgorithmRegistry} via an {@link AlgorithmRegistrar} bean.
+ * <p>
+ * The algorithm {@link #name()} is used as a stable, persistent identifier. It is stored
+ * alongside the {@link EncryptedKeyset} and used by the {@link AlgorithmRegistry} and
+ * {@link KeysetFactory} to resolve the correct implementation at runtime. It must
+ * therefore be unique across all registered algorithms and must not change once
+ * key material has been encrypted with it.
  *
  * @author : Vladimir Spasic
  * @since : 21.08.23, Mon
+ * @see KeysetPurpose
+ * @see AlgorithmRegistry
  **/
 @NullMarked
 public interface Algorithm extends Serializable {
 
 	/**
-	 * Returns the name of the algorithm that is used to perform cryptographic operations.
+	 * Returns the stable, unique name of this algorithm. This value is persisted in the
+	 * {@link EncryptedKeyset} and used to resolve the algorithm at load time via the
+	 * {@link AlgorithmRegistry}. It must not change once key material has been created
+	 * with this algorithm.
 	 *
 	 * @return algorithm name, never {@literal null}.
 	 */
 	String name();
+
+	/**
+	 * Returns the intended cryptographic purpose of this algorithm. Purpose determines
+	 * which {@link Keyset keysets} this algorithm may be used with and constrains the
+	 * set of valid {@link #operations()}.
+	 *
+	 * @return keyset purpose, never {@literal null}.
+	 */
+	KeysetPurpose purpose();
 
 	/**
 	 * The type of the key material that is used by the algorithm.
@@ -39,10 +59,15 @@ public interface Algorithm extends Serializable {
 
 	/**
 	 * Collection of {@link KeysetOperation operations} this {@link Algorithm} can perform.
+	 * <p>
+	 * The returned set of operations must match the operations from the specified keyset
+	 * purpose.
 	 *
-	 * @return supported operations, never {@literal null}.
+	 * @return supported operations, never {@literal null} or empty.
 	 */
-	Set<KeysetOperation> operations();
+	default Set<KeysetOperation> operations() {
+		return purpose().operations();
+	}
 
 	/**
 	 * Checks if the algorithm supports the given operation.
@@ -51,7 +76,7 @@ public interface Algorithm extends Serializable {
 	 * @return {@code true} if the algorithm supports the operation, {@code false} otherwise.
 	 */
 	default boolean supports(KeysetOperation operation) {
-		return operations().contains(operation);
+		return purpose().isOperationSupported(operation);
 	}
 
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AlgorithmRegistrar.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AlgorithmRegistrar.java
@@ -1,0 +1,32 @@
+package com.konfigyr.crypto;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Interface used for registering {@link Algorithm} instances with an {@link AlgorithmRegistry}.
+ * <p>
+ * Implement this interface and expose the implementation as a Spring {@code @Bean} to
+ * contribute custom or third-party algorithms to the registry. Each cryptographic library
+ * module ({@code konfigyr-crypto-tink}, {@code konfigyr-crypto-jose}) registers its own
+ * built-in algorithms this way during auto-configuration.
+ * <p>
+ * Registrations are processed at application context startup, before the registry is
+ * sealed. Attempting to register an algorithm after the context has started will throw
+ * an {@link IllegalStateException}.
+ *
+ * @author : Vladimir Spasic
+ * @since : 15.05.26, Fri
+ * @see AlgorithmRegistry
+ **/
+@NullMarked
+@FunctionalInterface
+public interface AlgorithmRegistrar {
+
+	/**
+	 * Register {@link Algorithm} instances with the given {@link AlgorithmRegistry}.
+	 *
+	 * @param registry the registry to register algorithms with, can't be {@literal null}
+	 */
+	void register(AlgorithmRegistry registry);
+
+}

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AlgorithmRegistry.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AlgorithmRegistry.java
@@ -1,0 +1,79 @@
+package com.konfigyr.crypto;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Registry that acts as the canonical source of all known {@link Algorithm} instances
+ * within the application.
+ * <p>
+ * The registry serves two purposes. First, it provides a controlled vocabulary: only
+ * algorithms registered at startup can be resolved at runtime, which prevents algorithm
+ * confusion attacks where a crafted {@link EncryptedKeyset} references an unknown or
+ * unexpected algorithm name. Second, it is the resolution mechanism used by
+ * {@link KeysetFactory} implementations to convert the algorithm name stored in an
+ * {@link EncryptedKeyset} back to a concrete {@link Algorithm} instance.
+ * <p>
+ * Algorithms are contributed to the registry via {@link AlgorithmRegistrar} beans, which
+ * are collected and invoked during application context initialisation. The registry is
+ * sealed after all singletons have been instantiated, and any attempt to register an
+ * algorithm after that point will throw an {@link IllegalStateException}.
+ * <p>
+ * Algorithm names must be globally unique. Attempting to register two different
+ * {@link Algorithm} instances under the same name will throw an
+ * {@link IllegalArgumentException}.
+ *
+ * @author : Vladimir Spasic
+ * @since : 15.05.26, Fri
+ * @see AlgorithmRegistrar
+ * @see KeysetFactory
+ **/
+@NullMarked
+public interface AlgorithmRegistry {
+
+	/**
+	 * Registers the given {@link Algorithm} with this registry.
+	 * <p>
+	 * This method must only be called during application context initialisation, before
+	 * the registry is sealed. Registering the same {@link Algorithm} instance more than
+	 * once is idempotent. Registering a different instance under an already-used name
+	 * will throw {@link IllegalArgumentException}.
+	 *
+	 * @param algorithm algorithm to register, can't be {@literal null}
+	 * @throws IllegalStateException when the registry has been sealed after context startup
+	 * @throws IllegalArgumentException when a different algorithm with the same name is
+	 * already registered
+	 */
+	void register(Algorithm algorithm);
+
+	/**
+	 * Looks up an {@link Algorithm} by its {@link Algorithm#name() name}.
+	 *
+	 * @param name the algorithm name to look up, can't be {@literal null}
+	 * @return matching algorithm, or an empty {@link Optional} if none is registered
+	 */
+	Optional<Algorithm> find(String name);
+
+	/**
+	 * Resolves an {@link Algorithm} by its {@link Algorithm#name() name}, throwing if
+	 * none is registered.
+	 *
+	 * @param name the algorithm name to resolve, can't be {@literal null}
+	 * @return matching algorithm, never {@literal null}
+	 * @throws CryptoException.UnknownAlgorithmException when no algorithm with the given
+	 * name is registered
+	 */
+	default Algorithm resolve(String name) {
+		return find(name).orElseThrow(() -> new CryptoException.UnknownAlgorithmException(name));
+	}
+
+	/**
+	 * Returns all algorithms currently registered in this registry.
+	 *
+	 * @return unmodifiable collection of registered algorithms, never {@literal null}
+	 */
+	Collection<Algorithm> algorithms();
+
+}

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoAutoConfiguration.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoAutoConfiguration.java
@@ -8,9 +8,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 
 /**
- * Autoconfiguration class used to create the {@link KeysetStore}. This configuration
- * requires that the {@link KeysetFactory} Spring Bean is present in the application
- * context.
+ * Autoconfiguration class used to create the {@link AlgorithmRegistry} and
+ * {@link KeysetStore}. This configuration requires that at least one {@link KeysetFactory}
+ * Spring Bean is present in the application context.
+ * <p>
+ * The {@link AlgorithmRegistry} bean is created by collecting all {@link AlgorithmRegistrar}
+ * beans from the context and invoking them in order. Cryptographic library modules
+ * ({@code konfigyr-crypto-tink}, {@code konfigyr-crypto-jose}) register their built-in
+ * algorithms this way via {@code @AutoConfigureBefore} ordering.
  * <p>
  * This configuration also declares an in-memory implementation of the
  * {@link KeysetRepository} that should not be used in production. It is recommended to
@@ -24,6 +29,14 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnBean(KeysetFactory.class)
 @ConditionalOnMissingBean(KeysetStore.class)
 public class CryptoAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(AlgorithmRegistry.class)
+	AlgorithmRegistry algorithmRegistry(ObjectProvider<@NonNull AlgorithmRegistrar> registrars) {
+		final AlgorithmRegistry registry = new SimpleAlgorithmRegistry();
+		registrars.forEach(registrar -> registrar.register(registry));
+		return registry;
+	}
 
 	@Bean
 	@ConditionalOnMissingBean(KeysetRepository.class)

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoException.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoException.java
@@ -42,6 +42,39 @@ public abstract class CryptoException extends RuntimeException {
 	}
 
 	/**
+	 * Exception thrown when the {@link AlgorithmRegistry} cannot resolve an algorithm
+	 * for the given name. This typically means the algorithm was never registered or
+	 * the stored {@link EncryptedKeyset} references an algorithm that is no longer
+	 * available in the current application context.
+	 */
+	public static class UnknownAlgorithmException extends CryptoException {
+
+		@Serial
+		private static final long serialVersionUID = SERIAL;
+
+		private final String algorithmName;
+
+		/**
+		 * Creates a new {@link UnknownAlgorithmException} for the given algorithm name.
+		 *
+		 * @param algorithmName the unresolvable algorithm name, can't be {@literal null}
+		 */
+		public UnknownAlgorithmException(String algorithmName) {
+			super("No algorithm registered with name '" + algorithmName + "'. Make sure the "
+					+ "algorithm is registered via an AlgorithmRegistrar bean.");
+			this.algorithmName = algorithmName;
+		}
+
+		/**
+		 * @return the algorithm name that could not be resolved, never {@literal null}
+		 */
+		public @NonNull String getAlgorithmName() {
+			return algorithmName;
+		}
+
+	}
+
+	/**
 	 * Exception thrown when the algorithm is not supported by the {@link Keyset}
 	 * implementation, or it can't be used by a specific {@link KeysetOperation}.
 	 */

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/Keyset.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/Keyset.java
@@ -16,9 +16,19 @@ import java.util.stream.Stream;
  * Keys in a {@link Keyset} get a unique identifier and, depending on the implementation,
  * a key status which allows disabling keys without removing them from a {@link Keyset}.
  * <p>
- * The designated primary key within the {@link Keyset} is used to perform sign and
- * encrypt operations. Non-primary keys are used only to perform signature verification
- * and decrypt operations if they are not in a disabled state.
+ * The designated primary key within the {@link Keyset} is used to perform the active
+ * cryptographic operation (sign or encrypt). Non-primary keys are used only for
+ * the corresponding passive operation (verify or decrypt) when they are not
+ * in a disabled state.
+ * <p>
+ * Which operations a keyset supports is determined by its {@link Algorithm#purpose()}:
+ * <ul>
+ *     <li>{@link KeysetPurpose#SIGNING} supports {@link #sign(ByteArray)} and
+ *         {@link #verify(ByteArray, ByteArray)}.</li>
+ *     <li>{@link KeysetPurpose#ENCRYPTION} supports {@link #encrypt(ByteArray)} and
+ *         {@link #decrypt(ByteArray)}.</li>
+ * </ul>
+ * All other operations throw {@link CryptoException.UnsupportedKeysetOperationException}.
  * <p>
  * Rotating cryptographic keys is a recommended security practice. Some industry
  * standards, such as Payment Card Industry Data Security Standard (PCI DSS), require a
@@ -59,60 +69,91 @@ public interface Keyset extends KeysetDefinition, Iterable<Key> {
 	}
 
 	/**
-	 * Encrypts the given byte buffer wrapped inside a {@link ByteArray}.
+	 * Encrypts the given byte buffer wrapped inside a {@link ByteArray}. Only supported when
+	 * {@link Algorithm#purpose()} is {@link KeysetPurpose#ENCRYPTION}.
 	 *
 	 * @param data Data wrapped as a byte buffer that should be encrypted, can't be {@literal null}.
 	 * @return Encrypted data wrapped inside a byte buffer.
+	 * @throws CryptoException.UnsupportedKeysetOperationException when the algorithm does not
+	 * support {@link KeysetOperation#ENCRYPT}.
 	 */
 	default ByteArray encrypt(ByteArray data) {
 		return encrypt(data, null);
 	}
 
 	/**
-	 * Encrypt the byte buffer with additional data to be used as authentication context when performing encryption.
+	 * Encrypt the byte buffer with additional data to be used as authentication context when
+	 * performing encryption. Only supported when {@link Algorithm#purpose()} is
+	 * {@link KeysetPurpose#ENCRYPTION}.
 	 *
 	 * @param data Data wrapped as a byte buffer that should be encrypted, can't be {@literal null}.
-	 * @param context Authentication context byte bugger, can be {@literal null}.
+	 * @param context Authentication context byte buffer, can be {@literal null}.
 	 * @return Encrypted data wrapped inside a byte buffer.
+	 * @throws CryptoException.UnsupportedKeysetOperationException when the algorithm does not
+	 * support {@link KeysetOperation#ENCRYPT}.
 	 */
-	ByteArray encrypt(ByteArray data, @Nullable ByteArray context);
+	default ByteArray encrypt(ByteArray data, @Nullable ByteArray context) {
+		throw new CryptoException.UnsupportedKeysetOperationException(
+				getName(), KeysetOperation.ENCRYPT, getAlgorithm().operations());
+	}
 
 	/**
-	 * Decrypt the given byte buffer wrapped inside a {@link ByteArray}.
+	 * Decrypt the given byte buffer wrapped inside a {@link ByteArray}. Only supported when
+	 * {@link Algorithm#purpose()} is {@link KeysetPurpose#ENCRYPTION}.
 	 *
 	 * @param cipher Data wrapped as a byte buffer that should be decrypted, can't be {@literal null}.
 	 * @return Decrypted data wrapped inside a byte buffer.
+	 * @throws CryptoException.UnsupportedKeysetOperationException when the algorithm does not
+	 * support {@link KeysetOperation#DECRYPT}.
 	 */
 	default ByteArray decrypt(ByteArray cipher) {
 		return decrypt(cipher, null);
 	}
 
 	/**
-	 * Decrypt the byte buffer with additional data was used during encryption as authentication context.
+	 * Decrypt the byte buffer with additional data that was used during encryption as
+	 * authentication context. Only supported when {@link Algorithm#purpose()} is
+	 * {@link KeysetPurpose#ENCRYPTION}.
 	 *
 	 * @param cipher Data wrapped as a byte buffer that should be decrypted, can't be {@literal null}.
-	 * @param context Authentication context byte bugger, can be {@literal null}.
+	 * @param context Authentication context byte buffer, can be {@literal null}.
 	 * @return Decrypted data wrapped inside a byte buffer.
+	 * @throws CryptoException.UnsupportedKeysetOperationException when the algorithm does not
+	 * support {@link KeysetOperation#DECRYPT}.
 	 */
-	ByteArray decrypt(ByteArray cipher, @Nullable ByteArray context);
+	default ByteArray decrypt(ByteArray cipher, @Nullable ByteArray context) {
+		throw new CryptoException.UnsupportedKeysetOperationException(
+				getName(), KeysetOperation.DECRYPT, getAlgorithm().operations());
+	}
 
 	/**
-	 * Signs the data wrapped inside a {@link ByteArray}. This method would return a {@link ByteArray} that
-	 * contains the digital signature.
+	 * Signs the data wrapped inside a {@link ByteArray}. Only supported when
+	 * {@link Algorithm#purpose()} is {@link KeysetPurpose#SIGNING}.
 	 *
 	 * @param data Data wrapped as a byte buffer that should be signed, can't be {@literal null}.
 	 * @return digital signature wrapped inside a byte buffer.
+	 * @throws CryptoException.UnsupportedKeysetOperationException when the algorithm does not
+	 * support {@link KeysetOperation#SIGN}.
 	 */
-	ByteArray sign(ByteArray data);
+	default ByteArray sign(ByteArray data) {
+		throw new CryptoException.UnsupportedKeysetOperationException(
+				getName(), KeysetOperation.SIGN, getAlgorithm().operations());
+	}
 
 	/**
-	 * Verifies if digital signature of the data wrapped inside a {@link ByteArray} is correct.
+	 * Verifies if the digital signature of the data wrapped inside a {@link ByteArray} is
+	 * correct. Only supported when {@link Algorithm#purpose()} is {@link KeysetPurpose#SIGNING}.
 	 *
 	 * @param signature Signature wrapped as a byte buffer that should be verified, can't be {@literal null}.
 	 * @param data Original data wrapped as a byte buffer from which the signature is created, can't be {@literal null}.
 	 * @return {@code true} if the signature is valid, {@code false} otherwise.
+	 * @throws CryptoException.UnsupportedKeysetOperationException when the algorithm does not
+	 * support {@link KeysetOperation#VERIFY}.
 	 */
-	boolean verify(ByteArray signature, ByteArray data);
+	default boolean verify(ByteArray signature, ByteArray data) {
+		throw new CryptoException.UnsupportedKeysetOperationException(
+				getName(), KeysetOperation.VERIFY, getAlgorithm().operations());
+	}
 
 	/**
 	 * Lifecycle method that is used to rotate cryptographic keys within the {@link Keyset}.

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetPurpose.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetPurpose.java
@@ -1,0 +1,69 @@
+package com.konfigyr.crypto;
+
+import java.util.Set;
+
+/**
+ * Defines the intended cryptographic purpose of a {@link Keyset}. Keys within the keyset
+ * can only be used for the operations allowed by its purpose. The purpose also determines
+ * which algorithms are supported for the key versions that are part of the keyset.
+ * <p>
+ * When cryptographic keys are created, a purpose and the algorithm must be defined. The
+ * {@link KeysetStore} allows update of the acutal cryptographic algorithm when new key
+ * versions are created, subject to the scope of its purpose, but its purpose cannot be
+ * changed.
+ * <p>
+ * This means that keysets with the same purpose may use different underlying algorithms,
+ * but they must support the same set of cryptographic operations.
+ *
+ * @author : Vladimir Spasic
+ * @since : 15.05.26, Fri
+ * @see Algorithm#purpose()
+ * @see Keyset
+ **/
+public enum KeysetPurpose {
+
+	/**
+	 * The keyset is used for symmetric or hybrid data encryption and decryption.
+	 * <p>
+	 * Supported operations: {@link KeysetOperation#ENCRYPT}, {@link KeysetOperation#DECRYPT}.
+	 * <p>
+	 * Applicable algorithms include AES-GCM, AES-EAX, AES-CTR-HMAC, and hybrid
+	 * encryption schemes such as ECIES and DHKEM.
+	 */
+	ENCRYPTION(KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+
+	/**
+	 * The keyset is used to produce and verify digital signatures or MACs.
+	 * <p>
+	 * Supported operations: {@link KeysetOperation#SIGN}, {@link KeysetOperation#VERIFY}.
+	 * <p>
+	 * Applicable algorithms include ECDSA, Ed25519, RSA-PSS, and HMAC variants.
+	 */
+	SIGNING(KeysetOperation.SIGN, KeysetOperation.VERIFY);
+
+	private final Set<KeysetOperation> operations;
+
+	KeysetPurpose(KeysetOperation... operations) {
+		this.operations = Set.of(operations);
+	}
+
+	/**
+	 * Returns which keyset operations are supported for this purpose.
+	 *
+	 * @return the supported operations, never {@literal null}.
+	 */
+	public Set<KeysetOperation> operations() {
+		return operations;
+	}
+
+	/**
+	 * Checks if this purpose supports the given operation.
+	 *
+	 * @param operation key operation to be checked, never {@literal null}.
+	 * @return {@code true} if the operation is supported, {@code false} otherwise.
+	 */
+	public boolean isOperationSupported(KeysetOperation operation) {
+		return operations.contains(operation);
+	}
+
+}

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SimpleAlgorithmRegistry.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SimpleAlgorithmRegistry.java
@@ -1,0 +1,67 @@
+package com.konfigyr.crypto;
+
+import org.jspecify.annotations.NullMarked;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.util.Assert;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default implementation of {@link AlgorithmRegistry} that stores algorithms in a
+ * {@link ConcurrentHashMap} and seals itself once all Spring singletons have been
+ * instantiated via {@link SmartInitializingSingleton}.
+ * <p>
+ * Once sealed, any call to {@link #register(Algorithm)} will throw an
+ * {@link IllegalStateException}. This prevents runtime mutation of the registry after
+ * the application is fully started, which would otherwise open an attack surface for
+ * algorithm injection.
+ *
+ * @author : Vladimir Spasic
+ * @since : 15.05.26, Fri
+ * @see AlgorithmRegistry
+ * @see AlgorithmRegistrar
+ **/
+@NullMarked
+public class SimpleAlgorithmRegistry implements AlgorithmRegistry, SmartInitializingSingleton {
+
+	private final ConcurrentHashMap<String, Algorithm> algorithms = new ConcurrentHashMap<>();
+
+	private volatile boolean sealed = false;
+
+	@Override
+	public void afterSingletonsInstantiated() {
+		sealed = true;
+	}
+
+	@Override
+	public void register(Algorithm algorithm) {
+		Assert.hasText(algorithm.name(), "Algorithm name must not be blank");
+
+		if (sealed) {
+			throw new IllegalStateException("Cannot register algorithm '" + algorithm.name()
+					+ "': AlgorithmRegistry is sealed after application context startup");
+		}
+
+		if (algorithms.containsKey(algorithm.name())) {
+			throw new IllegalArgumentException("An algorithm with name '" + algorithm.name()
+				+ "' is already registered: " + algorithms.get(algorithm.name()));
+		}
+
+		algorithms.put(algorithm.name(), algorithm);
+	}
+
+	@Override
+	public Optional<Algorithm> find(String name) {
+		Assert.hasText(name, "Algorithm name must not be blank");
+		return Optional.ofNullable(algorithms.get(name));
+	}
+
+	@Override
+	public Collection<Algorithm> algorithms() {
+		return Collections.unmodifiableCollection(algorithms.values());
+	}
+
+}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/AlgorithmRegistryTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/AlgorithmRegistryTest.java
@@ -1,0 +1,136 @@
+package com.konfigyr.crypto;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AlgorithmRegistryTest {
+
+	SimpleAlgorithmRegistry registry;
+
+	@BeforeEach
+	void setup() {
+		registry = new SimpleAlgorithmRegistry();
+	}
+
+	@Test
+	@DisplayName("should register and find algorithm by name")
+	void shouldRegisterAndFindAlgorithm() {
+		final var algorithm = algorithm("test:algo");
+
+		registry.register(algorithm);
+
+		assertThat(registry.find("test:algo"))
+			.isPresent()
+			.contains(algorithm);
+	}
+
+	@Test
+	@DisplayName("should return empty optional for an unregistered algorithm name")
+	void shouldReturnEmptyForUnknownAlgorithm() {
+		assertThat(registry.find("unknown")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should resolve registered algorithm by name")
+	void shouldResolveAlgorithm() {
+		final var algorithm = algorithm("test:algo");
+
+		registry.register(algorithm);
+
+		assertThat(registry.resolve("test:algo"))
+			.isEqualTo(algorithm);
+	}
+
+	@Test
+	@DisplayName("should throw when resolving an unregistered algorithm name")
+	void shouldThrowWhenResolvingUnknownAlgorithm() {
+		assertThatExceptionOfType(CryptoException.UnknownAlgorithmException.class)
+			.isThrownBy(() -> registry.resolve("unknown"))
+			.withMessageContaining("unknown");
+	}
+
+	@Test
+	@DisplayName("should return all registered algorithms")
+	void shouldReturnAllRegisteredAlgorithms() {
+		final var a1 = algorithm("test:algo-1");
+		final var a2 = algorithm("test:algo-2");
+		final var a3 = algorithm("test:algo-3");
+
+		registry.register(a1);
+		registry.register(a2);
+		registry.register(a3);
+
+		assertThat(registry.algorithms())
+			.containsExactlyInAnyOrder(a1, a2, a3);
+	}
+
+	@Test
+	@DisplayName("should return an empty collection when no algorithms are registered")
+	void shouldReturnEmptyCollectionWhenNoAlgorithmsRegistered() {
+		assertThat(registry.algorithms()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should throw when registering a duplicate algorithm name")
+	void shouldThrowOnDuplicateName() {
+		registry.register(algorithm("test:algo"));
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> registry.register(algorithm("test:algo")))
+			.withMessageContaining("test:algo");
+	}
+
+	@Test
+	@DisplayName("should throw when registering an algorithm after the registry is sealed")
+	void shouldThrowWhenSealedAfterStartup() {
+		registry.afterSingletonsInstantiated();
+
+		assertThatIllegalStateException()
+			.isThrownBy(() -> registry.register(algorithm("test:algo")))
+			.withMessageContaining("sealed");
+	}
+
+	@Test
+	@DisplayName("should seal the registry and still allow read operations after startup")
+	void shouldAllowReadOperationsAfterSealing() {
+		final var algorithm = algorithm("test:algo");
+
+		registry.register(algorithm);
+		registry.afterSingletonsInstantiated();
+
+		assertThat(registry.find("test:algo")).contains(algorithm);
+		assertThat(registry.resolve("test:algo")).isEqualTo(algorithm);
+		assertThat(registry.algorithms()).containsExactly(algorithm);
+	}
+
+	@Test
+	@DisplayName("should throw when registering an algorithm with a blank name")
+	void shouldThrowForBlankAlgorithmName() {
+		final var algorithm = algorithm("");
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> registry.register(algorithm));
+	}
+
+	@Test
+	@DisplayName("should throw when looking up with a blank name")
+	void shouldThrowWhenFindingWithBlankName() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> registry.find(""));
+	}
+
+	private static Algorithm algorithm(String name) {
+		final Algorithm algorithm = mock(Algorithm.class);
+		when(algorithm.name()).thenReturn(name);
+		return algorithm;
+	}
+
+}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/KeysetPurposeSanityTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/KeysetPurposeSanityTest.java
@@ -1,0 +1,39 @@
+package com.konfigyr.crypto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeysetPurposeSanityTest {
+
+	@MethodSource("purposes")
+	@ParameterizedTest(name = "Purpose {0} supports: {1}")
+	@DisplayName("should list supported operations for keyset purpose")
+	void sanity(KeysetPurpose purpose, Set<KeysetOperation> operations) {
+		assertThat(purpose.operations())
+			.as("Operations for purpose %s must match", purpose)
+			.containsExactlyInAnyOrderElementsOf(operations);
+
+		assertThat(operations)
+			.as("All operations must be supported by purpose %s", purpose)
+			.allMatch(purpose::isOperationSupported);
+	}
+
+	static Stream<Arguments> purposes() {
+		return Stream.of(
+			Arguments.argumentSet("encrypt", KeysetPurpose.ENCRYPTION, Set.of(
+				KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT
+			)),
+			Arguments.argumentSet("sign", KeysetPurpose.SIGNING, Set.of(
+				KeysetOperation.SIGN, KeysetOperation.VERIFY
+			))
+		);
+	}
+
+}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepostoryKeysetStoreTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepostoryKeysetStoreTest.java
@@ -11,7 +11,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 
 import java.io.IOException;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -392,14 +391,14 @@ class RepostoryKeysetStoreTest {
 
 		@NonNull
 		@Override
-		public KeyType type() {
-			return KeyType.OCTET;
+		public KeysetPurpose purpose() {
+			return KeysetPurpose.ENCRYPTION;
 		}
 
 		@NonNull
 		@Override
-		public Set<KeysetOperation> operations() {
-			return Set.of(KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT);
+		public KeyType type() {
+			return KeyType.OCTET;
 		}
 
 	}

--- a/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
+++ b/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -64,18 +63,25 @@ class JdbcKeysetRepositoryTest {
 
 	enum TestAlgorithm implements Algorithm {
 
-		ENCRYPTION, SIGNING;
+		ENCRYPTION(KeysetPurpose.ENCRYPTION),
+		SIGNING(KeysetPurpose.SIGNING);
+
+		private final KeysetPurpose purpose;
+
+		TestAlgorithm(KeysetPurpose purpose) {
+			this.purpose = purpose;
+		}
+
+		@NonNull
+		@Override
+		public KeysetPurpose purpose() {
+			return purpose;
+		}
 
 		@NonNull
 		@Override
 		public KeyType type() {
 			return KeyType.OCTET;
-		}
-
-		@NonNull
-		@Override
-		public Set<KeysetOperation> operations() {
-			return Set.of(KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT);
 		}
 
 	}

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAlgorithm.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAlgorithm.java
@@ -2,23 +2,41 @@ package com.konfigyr.crypto.jose;
 
 import com.konfigyr.crypto.Algorithm;
 import com.konfigyr.crypto.KeyType;
-import com.konfigyr.crypto.KeysetOperation;
+import com.konfigyr.crypto.KeysetPurpose;
 import com.nimbusds.jose.JWEAlgorithm;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.JWKGenerator;
+import com.nimbusds.jose.jwk.gen.OctetSequenceKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import lombok.EqualsAndHashCode;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.util.Assert;
 
-import java.util.Set;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
- * An enumeration of the cryptographic algorithms defined by the following RFCs:
+ * Collection of {@link Algorithm algorithms} supported by the
+ * <a href="https://connect2id.com/products/nimbus-jose-jwt">Nimbus JOSE JWT</a> library.
+ * <p>
+ * Algorithms are grouped by their intended cryptographic purpose:
  * <ul>
- *     <li>
- *         <a target="_blank" href="https://tools.ietf.org/html/rfc7518">JSON Web Algorithms (JWA)</a>
- *     </li>
- *     <li>
- *         <a target="_blank" href="https://tools.ietf.org/html/rfc7516">JSON Web Encryption (JWE)</a>
- *     </li>
+ *     <li>{@link KeysetPurpose#SIGNING} — JWS algorithms (HMAC, ECDSA, RSA-PSS, RSA-PKCS1)</li>
+ *     <li>{@link KeysetPurpose#ENCRYPTION} — JWE key management algorithms (RSA-OAEP,
+ *         AES Key Wrap, ECDH-ES, AES-GCM Key Wrap)</li>
  * </ul>
+ * <p>
+ * Algorithm names follow the IANA-registered names from RFC 7518 (JWA), prefixed with
+ * {@code "jose:"} to identify this factory family.
+ * <p>
+ * Custom JOSE algorithms can be created by constructing an instance directly and registering
+ * it via an {@link com.konfigyr.crypto.AlgorithmRegistrar} bean.
  *
  * @author : Vladimir Spasic
  * @since : 24.11.25, Mon
@@ -26,173 +44,299 @@ import java.util.Set;
  * @see com.nimbusds.jose.JWEAlgorithm
  */
 @NullMarked
-public enum JoseAlgorithm implements Algorithm {
+@EqualsAndHashCode(of = "name")
+public final class JoseAlgorithm implements Algorithm {
+
+	/* -------------------------------------------------------------------------
+	 * HMAC symmetric signing algorithms (KeysetPurpose.SIGNING)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * HMAC using SHA-256.
+	 * HMAC using SHA-256. NIST FIPS 198-1.
 	 */
-	HS256(KeyType.OCTET, JWSAlgorithm.HS256, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm HS256 = new JoseAlgorithm(
+		"jose:HS256", KeyType.OCTET, KeysetPurpose.SIGNING, JWSAlgorithm.HS256,
+		() -> new OctetSequenceKeyGenerator(256)
+	);
 
 	/**
-	 * HMAC using SHA-384.
+	 * HMAC using SHA-384. NIST FIPS 198-1.
 	 */
-	HS384(KeyType.OCTET, JWSAlgorithm.HS384, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm HS384 = new JoseAlgorithm(
+		"jose:HS384", KeyType.OCTET, KeysetPurpose.SIGNING, JWSAlgorithm.HS384,
+		() -> new OctetSequenceKeyGenerator(384)
+	);
 
 	/**
-	 * HMAC using SHA-512.
+	 * HMAC using SHA-512. NIST FIPS 198-1.
 	 */
-	HS512(KeyType.OCTET, JWSAlgorithm.HS512, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm HS512 = new JoseAlgorithm(
+		"jose:HS512", KeyType.OCTET, KeysetPurpose.SIGNING, JWSAlgorithm.HS512,
+		() -> new OctetSequenceKeyGenerator(512)
+	);
+
+	/* -------------------------------------------------------------------------
+	 * ECDSA asymmetric signing algorithms (KeysetPurpose.SIGNING)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * RSASSA-PKCS1-v1_5 using SHA-256. This algorithm is still widely supported but explicitly
-	 * disallowed for new systems in NIST SP 800-131A.
+	 * ECDSA using NIST P-256 and SHA-256. NIST FIPS 186-5.
 	 */
-	RS256(KeyType.RSA, JWSAlgorithm.RS256, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm ES256 = new JoseAlgorithm(
+		"jose:ES256", KeyType.EC, KeysetPurpose.SIGNING, JWSAlgorithm.ES256, () -> new ECKeyGenerator(Curve.P_256)
+	);
 
 	/**
-	 * RSASSA-PKCS1-v1_5 using SHA-384. This algorithm is still widely supported but explicitly
-	 * disallowed for new systems in NIST SP 800-131A.
+	 * ECDSA using NIST P-384 and SHA-384. NIST FIPS 186-5.
 	 */
-	RS384(KeyType.RSA, JWSAlgorithm.RS384, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm ES384 = new JoseAlgorithm(
+		"jose:ES384", KeyType.EC, KeysetPurpose.SIGNING, JWSAlgorithm.ES384, () -> new ECKeyGenerator(Curve.P_384)
+	);
 
 	/**
-	 * RSASSA-PKCS1-v1_5 using SHA-512. This algorithm is still widely supported but explicitly
-	 * disallowed for new systems in NIST SP 800-131A.
+	 * ECDSA using NIST P-521 and SHA-512. NIST FIPS 186-5.
 	 */
-	RS512(KeyType.RSA, JWSAlgorithm.RS512, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm ES512 = new JoseAlgorithm(
+		"jose:ES512", KeyType.EC, KeysetPurpose.SIGNING, JWSAlgorithm.ES512, () -> new ECKeyGenerator(Curve.P_521)
+	);
+
+	/* -------------------------------------------------------------------------
+	 * RSA-PSS asymmetric signing algorithms (KeysetPurpose.SIGNING)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * ECDSA using P-256 and SHA-256 (Recommended+).
+	 * RSASSA-PSS using SHA-256 and MGF1 with SHA-256. NIST FIPS 186-5, SP 800-131A Rev 2.
 	 */
-	ES256(KeyType.EC, JWSAlgorithm.ES256, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm PS256 = new JoseAlgorithm(
+		"jose:PS256", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.PS256,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS * 2)
+	);
 
 	/**
-	 * ECDSA using P-384 and SHA-384.
+	 * RSASSA-PSS using SHA-384 and MGF1 with SHA-384. NIST FIPS 186-5, SP 800-131A Rev 2.
 	 */
-	ES384(KeyType.EC, JWSAlgorithm.ES384, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm PS384 = new JoseAlgorithm(
+		"jose:PS384", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.PS384,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS * 2)
+	);
 
 	/**
-	 * ECDSA using P-521 and SHA-512.
+	 * RSASSA-PSS using SHA-512 and MGF1 with SHA-512. NIST FIPS 186-5, SP 800-131A Rev 2.
 	 */
-	ES512(KeyType.EC, JWSAlgorithm.ES512, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm PS512 = new JoseAlgorithm(
+		"jose:PS512", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.PS512,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS * 2)
+	);
+
+	/* -------------------------------------------------------------------------
+	 * RSA-PKCS1 signing algorithms (KeysetPurpose.SIGNING)
+	 * Included for JOSE interoperability only; disallowed for new applications
+	 * by NIST SP 800-131A Rev 2. Prefer PS256/PS384/PS512 for new designs.
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * RSASSA-PSS using SHA-256 and MGF1 with SHA-256.
+	 * RSASSA-PKCS1-v1_5 using SHA-256. Retained for JOSE interoperability only;
+	 * new applications should use {@link #PS256} instead.
 	 */
-	PS256(KeyType.RSA, JWSAlgorithm.PS256, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm RS256 = new JoseAlgorithm(
+		"jose:RS256", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.RS256,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+	);
 
 	/**
-	 * RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
+	 * RSASSA-PKCS1-v1_5 using SHA-384. Retained for JOSE interoperability only;
+	 * new applications should use {@link #PS384} instead.
 	 */
-	PS384(KeyType.RSA, JWSAlgorithm.PS384, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm RS384 = new JoseAlgorithm(
+		"jose:RS384", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.RS384,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+	);
 
 	/**
-	 * RSASSA-PSS using SHA-512 and MGF1 with SHA-512.
+	 * RSASSA-PKCS1-v1_5 using SHA-512. Retained for JOSE interoperability only;
+	 * new applications should use {@link #PS512} instead.
 	 */
-	PS512(KeyType.RSA, JWSAlgorithm.PS512, KeysetOperation.SIGN, KeysetOperation.VERIFY),
+	public static final JoseAlgorithm RS512 = new JoseAlgorithm(
+		"jose:RS512", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.RS512,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS * 2)
+	);
+
+	/* -------------------------------------------------------------------------
+	 * RSA-OAEP encryption algorithms (KeysetPurpose.ENCRYPTION)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * RSAES using Optimal Asymmetric Encryption Padding (OAEP) (RFC 3447),
-	 * with the SHA-256 hash function and the MGF1 with SHA-256 mask
-	 * generation function.
+	 * RSA-OAEP with SHA-256. NIST SP 800-56B Rev 2.
 	 */
-	RSA_OAEP_256(KeyType.RSA, JWEAlgorithm.RSA_OAEP_256, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm RSA_OAEP_256 = new JoseAlgorithm(
+		"jose:RSA-OAEP-256", KeyType.RSA, KeysetPurpose.ENCRYPTION, JWEAlgorithm.RSA_OAEP_256,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+	);
 
 	/**
-	 * RSAES using Optimal Asymmetric Encryption Padding (OAEP) (RFC 3447),
-	 * with the SHA-512 hash function and the MGF1 with SHA-384 mask
-	 * generation function.
+	 * RSA-OAEP with SHA-384. NIST SP 800-56B Rev 2.
 	 */
-	RSA_OAEP_384(KeyType.RSA, JWEAlgorithm.RSA_OAEP_384, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm RSA_OAEP_384 = new JoseAlgorithm(
+		"jose:RSA-OAEP-384", KeyType.RSA, KeysetPurpose.ENCRYPTION, JWEAlgorithm.RSA_OAEP_384,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+	);
 
 	/**
-	 * RSAES using Optimal Asymmetric Encryption Padding (OAEP) (RFC 3447),
-	 * with the SHA-512 hash function and the MGF1 with SHA-512 mask
-	 * generation function.
+	 * RSA-OAEP with SHA-512. NIST SP 800-56B Rev 2.
 	 */
-	RSA_OAEP_512(KeyType.RSA, JWEAlgorithm.RSA_OAEP_512, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm RSA_OAEP_512 = new JoseAlgorithm(
+		"jose:RSA-OAEP-512", KeyType.RSA, KeysetPurpose.ENCRYPTION, JWEAlgorithm.RSA_OAEP_512,
+		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS * 2)
+	);
+
+	/* -------------------------------------------------------------------------
+	 * AES Key Wrap encryption algorithms (KeysetPurpose.ENCRYPTION)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * Advanced Encryption Standard (AES) Key Wrap Algorithm (RFC 3394) using 128-bit keys.
+	 * AES Key Wrap (RFC 3394) using 128-bit keys. NIST SP 800-38F.
 	 */
-	A128KW(KeyType.OCTET, JWEAlgorithm.A128KW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm A128KW = new JoseAlgorithm(
+		"jose:A128KW", KeyType.OCTET, KeysetPurpose.ENCRYPTION, JWEAlgorithm.A128KW,
+		() -> new OctetSequenceKeyGenerator(128)
+	);
 
 	/**
-	 * Advanced Encryption Standard (AES) Key Wrap Algorithm (RFC 3394) using 192-bit keys.
+	 * AES Key Wrap (RFC 3394) using 192-bit keys. NIST SP 800-38F.
 	 */
-	A192KW(KeyType.OCTET, JWEAlgorithm.A192KW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm A192KW = new JoseAlgorithm(
+		"jose:A192KW", KeyType.OCTET, KeysetPurpose.ENCRYPTION, JWEAlgorithm.A192KW,
+		() -> new OctetSequenceKeyGenerator(192)
+	);
 
 	/**
-	 * Advanced Encryption Standard (AES) Key Wrap Algorithm (RFC 3394) using 256-bit keys.
+	 * AES Key Wrap (RFC 3394) using 256-bit keys. NIST SP 800-38F.
 	 */
-	A256KW(KeyType.OCTET, JWEAlgorithm.A256KW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm A256KW = new JoseAlgorithm(
+		"jose:A256KW", KeyType.OCTET, KeysetPurpose.ENCRYPTION, JWEAlgorithm.A256KW,
+		() -> new OctetSequenceKeyGenerator(256)
+	);
+
+	/* -------------------------------------------------------------------------
+	 * AES-GCM Key Wrap encryption algorithms (KeysetPurpose.ENCRYPTION)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * Elliptic Curve Diffie-Hellman Ephemeral Static (RFC 6090) key
-	 * agreement using the Concat KDF, as defined in section 5.8.1 of
-	 * NIST.800-56A, with the agreed-upon key being used directly as the
-	 * Content Encryption Key (CEK) (rather than being used to wrap the
-	 * CEK).
+	 * AES-GCM Key Wrap using 128-bit keys. NIST SP 800-38D.
 	 */
-	ECDH_ES(KeyType.EC, JWEAlgorithm.ECDH_ES, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm A128GCMKW = new JoseAlgorithm(
+		"jose:A128GCMKW", KeyType.OCTET, KeysetPurpose.ENCRYPTION, JWEAlgorithm.A128GCMKW,
+		() -> new OctetSequenceKeyGenerator(128)
+	);
 
 	/**
-	 * Elliptic Curve Diffie-Hellman Ephemeral Static key agreement per
-	 * "ECDH-ES", but where the agreed-upon key is used to wrap the Content
-	 * Encryption Key (CEK) with the "A128KW" function (rather than being
-	 * used directly as the CEK).
+	 * AES-GCM Key Wrap using 192-bit keys. NIST SP 800-38D.
 	 */
-	ECDH_ES_A128KW(KeyType.EC, JWEAlgorithm.ECDH_ES_A128KW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm A192GCMKW = new JoseAlgorithm(
+		"jose:A192GCMKW", KeyType.OCTET, KeysetPurpose.ENCRYPTION, JWEAlgorithm.A192GCMKW,
+		() -> new OctetSequenceKeyGenerator(192)
+	);
 
 	/**
-	 * Elliptic Curve Diffie-Hellman Ephemeral Static key agreement per
-	 * "ECDH-ES", but where the agreed-upon key is used to wrap the Content
-	 * Encryption Key (CEK) with the "A192KW" function (rather than being
-	 * used directly as the CEK).
+	 * AES-GCM Key Wrap using 256-bit keys. NIST SP 800-38D.
 	 */
-	ECDH_ES_A192KW(KeyType.EC, JWEAlgorithm.ECDH_ES_A192KW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm A256GCMKW = new JoseAlgorithm(
+		"jose:A256GCMKW", KeyType.OCTET, KeysetPurpose.ENCRYPTION, JWEAlgorithm.A256GCMKW,
+		() -> new OctetSequenceKeyGenerator(256)
+	);
+
+	/* -------------------------------------------------------------------------
+	 * ECDH-ES encryption algorithms (KeysetPurpose.ENCRYPTION)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * Elliptic Curve Diffie-Hellman Ephemeral Static key agreement per
-	 * "ECDH-ES", but where the agreed-upon key is used to wrap the Content
-	 * Encryption Key (CEK) with the "A256KW" function (rather than being
-	 * used directly as the CEK).
+	 * ECDH-ES using Concat KDF with the agreed-upon key as the CEK. NIST SP 800-56A Rev 3.
 	 */
-	ECDH_ES_A256KW(KeyType.EC, JWEAlgorithm.ECDH_ES_A256KW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm ECDH_ES = new JoseAlgorithm(
+		"jose:ECDH-ES", KeyType.EC, KeysetPurpose.ENCRYPTION, JWEAlgorithm.ECDH_ES,
+		() -> new ECKeyGenerator(Curve.P_256)
+	);
 
 	/**
-	 * AES in Galois/Counter Mode (GCM) (NIST.800-38D) 128-bit keys.
+	 * ECDH-ES with AES-128 Key Wrap of the CEK. NIST SP 800-56A Rev 3.
 	 */
-	A128GCMKW(KeyType.OCTET, JWEAlgorithm.A128GCMKW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm ECDH_ES_A128KW = new JoseAlgorithm(
+		"jose:ECDH-ES+A128KW", KeyType.EC, KeysetPurpose.ENCRYPTION, JWEAlgorithm.ECDH_ES_A128KW,
+		() -> new ECKeyGenerator(Curve.P_256)
+	);
 
 	/**
-	 * AES in Galois/Counter Mode (GCM) (NIST.800-38D) 192-bit keys.
+	 * ECDH-ES with AES-192 Key Wrap of the CEK. NIST SP 800-56A Rev 3.
 	 */
-	A192GCMKW(KeyType.OCTET, JWEAlgorithm.A192GCMKW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final JoseAlgorithm ECDH_ES_A192KW = new JoseAlgorithm(
+		"jose:ECDH-ES+A192KW", KeyType.EC, KeysetPurpose.ENCRYPTION, JWEAlgorithm.ECDH_ES_A192KW,
+		() -> new ECKeyGenerator(Curve.P_384)
+	);
 
 	/**
-	 * AES in Galois/Counter Mode (GCM) (NIST.800-38D) 256-bit keys.
+	 * ECDH-ES with AES-256 Key Wrap of the CEK. NIST SP 800-56A Rev 3.
 	 */
-	A256GCMKW(KeyType.OCTET, JWEAlgorithm.A256GCMKW, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT);
+	public static final JoseAlgorithm ECDH_ES_A256KW = new JoseAlgorithm(
+		"jose:ECDH-ES+A256KW", KeyType.EC, KeysetPurpose.ENCRYPTION, JWEAlgorithm.ECDH_ES_A256KW,
+		() -> new ECKeyGenerator(Curve.P_521)
+	);
 
+	/**
+	 * List of all built-in JOSE algorithm constants.
+	 */
+	public static final List<JoseAlgorithm> DEFAULT_ALGORITHMS = List.of(
+		HS256, HS384, HS512,
+		ES256, ES384, ES512,
+		PS256, PS384, PS512,
+		RS256, RS384, RS512,
+		RSA_OAEP_256, RSA_OAEP_384, RSA_OAEP_512,
+		A128KW, A192KW, A256KW,
+		A128GCMKW, A192GCMKW, A256GCMKW,
+		ECDH_ES, ECDH_ES_A128KW, ECDH_ES_A192KW, ECDH_ES_A256KW
+	);
+
+	private final String name;
 	private final KeyType type;
-	private final Set<KeysetOperation> operations;
+	private final KeysetPurpose purpose;
 	private final com.nimbusds.jose.Algorithm algorithm;
+	private final Supplier<JWKGenerator<? extends JWK>> generator;
 
-	JoseAlgorithm(KeyType type, com.nimbusds.jose.Algorithm algorithm, KeysetOperation... operations) {
+	/**
+	 * Creates a custom JOSE algorithm with an explicit name, key type, purpose, backing
+	 * JOSE algorithm identifier, and JWK generator.
+	 * <p>
+	 * The {@code name} must be unique across all registered algorithms and must not change
+	 * once key material has been created with this algorithm.
+	 *
+	 * @param name      stable unique algorithm name with {@code "jose:"} prefix, must not be blank
+	 * @param type      key material type, must not be {@literal null}
+	 * @param purpose   intended cryptographic purpose, must not be {@literal null}
+	 * @param algorithm the backing Nimbus JOSE algorithm identifier, must not be {@literal null}
+	 * @param generator JWK generator factory used to create key material, can be {@literal null}
+	 */
+	public JoseAlgorithm(
+		String name,
+		KeyType type,
+		KeysetPurpose purpose,
+		com.nimbusds.jose.Algorithm algorithm,
+		Supplier<JWKGenerator<? extends JWK>> generator
+	) {
+		Assert.isTrue(name.startsWith("jose:"), "JOSE algorithm names must start with 'jose:' prefix");
+		this.name = name;
 		this.type = type;
+		this.purpose = purpose;
 		this.algorithm = algorithm;
-		this.operations = Set.of(operations);
+		this.generator = generator;
 	}
 
-	/**
-	 * Method that returns the {@link com.nimbusds.jose.Algorithm JOSE Algorithm} that backs this
-	 * {@link JoseAlgorithm}.
-	 *
-	 * @return the backing JOSE algorithm, never {@literal null}.
-	 */
-	public com.nimbusds.jose.Algorithm algorithm() {
-		return algorithm;
+	@Override
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public KeysetPurpose purpose() {
+		return purpose;
 	}
 
 	@Override
@@ -200,9 +344,34 @@ public enum JoseAlgorithm implements Algorithm {
 		return type;
 	}
 
+	/**
+	 * Returns the Nimbus JOSE algorithm identifier that backs this algorithm.
+	 *
+	 * @return backing JOSE algorithm, never {@literal null}.
+	 */
+	public com.nimbusds.jose.Algorithm algorithm() {
+		return algorithm;
+	}
+
+	/**
+	 * Returns the JWK generator used to generate key material for this algorithm.
+	 *
+	 * @param <T> the JWK type produced by the generator
+	 * @return JWK generator, never {@literal null}.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T extends JWK> JWKGenerator<T> generator() {
+		return (JWKGenerator<T>) generator.get()
+			.keyID(UUID.randomUUID().toString())
+			.algorithm(algorithm)
+			.keyUse(JoseUtils.resolveKeyUse(purpose))
+			.keyOperations(JoseUtils.resolveKeyOperations(purpose))
+			.notBeforeTime(Date.from(Instant.ofEpochSecond(System.currentTimeMillis() / 1000)));
+	}
+
 	@Override
-	public Set<KeysetOperation> operations() {
-		return operations;
+	public String toString() {
+		return name;
 	}
 
 }

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAutoConfiguration.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAutoConfiguration.java
@@ -1,5 +1,7 @@
 package com.konfigyr.crypto.jose;
 
+import com.konfigyr.crypto.AlgorithmRegistrar;
+import com.konfigyr.crypto.AlgorithmRegistry;
 import com.konfigyr.crypto.CryptoAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -20,8 +22,13 @@ import org.springframework.context.annotation.Bean;
 public class JoseAutoConfiguration {
 
 	@Bean
-	JoseKeysetFactory joseKeysetFactory() {
-		return new JoseKeysetFactory();
+	AlgorithmRegistrar joseAlgorithmRegistrar() {
+		return registry -> JoseAlgorithm.DEFAULT_ALGORITHMS.forEach(registry::register);
+	}
+
+	@Bean
+	JoseKeysetFactory joseKeysetFactory(AlgorithmRegistry registry) {
+		return new JoseKeysetFactory(registry);
 	}
 
 }

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseKeysetFactory.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseKeysetFactory.java
@@ -4,11 +4,11 @@ import com.konfigyr.crypto.*;
 import com.konfigyr.io.ByteArray;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.gen.JWKGenerator;
 import com.nimbusds.jose.shaded.gson.Gson;
 import com.nimbusds.jose.shaded.gson.GsonBuilder;
 import com.nimbusds.jose.shaded.gson.JsonParseException;
 import com.nimbusds.jose.shaded.gson.reflect.TypeToken;
+import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 
 import java.io.IOException;
@@ -32,8 +32,9 @@ import java.util.Map;
  * API, like {@link com.nimbusds.jose.proc.JWEKeySelector JWEKeySelector} and
  * {@link com.nimbusds.jose.proc.JWSKeySelector JWSKeySelector}.
  * <p>
- * Keep in mind that the {@link JsonWebKeyset} would generate {@link com.nimbusds.jose.JWEObject JWE}
- * when encrypting the data, and {@link com.nimbusds.jose.JWSObject JWS} when signing it.
+ * Keep in mind that the {@link JsonWebKeyset} generates a {@link com.nimbusds.jose.JWEObject JWE}
+ * token when encrypting data using a {@link KeysetPurpose#ENCRYPTION} algorithm, and a
+ * {@link com.nimbusds.jose.JWSObject JWS} token when signing data.
  *
  * @author : Vladimir Spasic
  * @since : 24.11.25, Mon
@@ -41,22 +42,21 @@ import java.util.Map;
  * @see JsonWebKeyset
  **/
 @NullMarked
+@RequiredArgsConstructor
 public class JoseKeysetFactory implements KeysetFactory {
 
 	private static final TypeToken<?> JSON_KEY_TYPE = TypeToken.getParameterized(Map.class, String.class, Object.class);
 	private static final TypeToken<?> JSON_KEYS_TYPE = TypeToken.getArray(JSON_KEY_TYPE.getType());
 
+	private final AlgorithmRegistry registry;
 	private final Gson gson = new GsonBuilder()
 		.create();
 
 	@Override
 	public boolean supports(EncryptedKeyset encryptedKeyset) {
-		for (JoseAlgorithm algorithm : JoseAlgorithm.values()) {
-			if (algorithm.name().equals(encryptedKeyset.getAlgorithm())) {
-				return true;
-			}
-		}
-		return false;
+		return registry.find(encryptedKeyset.getAlgorithm())
+			.filter(a -> a instanceof JoseAlgorithm)
+			.isPresent();
 	}
 
 	@Override
@@ -66,11 +66,14 @@ public class JoseKeysetFactory implements KeysetFactory {
 
 	@Override
 	public Keyset create(KeyEncryptionKey kek, KeysetDefinition definition) {
-		final JWKGenerator<?> generator = JoseUtils.generatorForDefinition(definition);
+		if (!(definition.getAlgorithm() instanceof JoseAlgorithm joseAlgorithm)) {
+			throw new CryptoException.UnsupportedAlgorithmException(definition.getAlgorithm());
+		}
+
 		final JWK key;
 
 		try {
-			key = generator.generate();
+			key = joseAlgorithm.generator().generate();
 		} catch (JOSEException ex) {
 			throw new CryptoException.KeysetException(definition, "Failed to create JWK", ex);
 		}
@@ -78,7 +81,7 @@ public class JoseKeysetFactory implements KeysetFactory {
 		return JsonWebKeyset.builder(new JsonWebKey(key, KeyStatus.ENABLED, true))
 			.keyEncryptionKey(kek)
 			.name(definition.getName())
-			.algorithm((JoseAlgorithm) definition.getAlgorithm())
+			.algorithm(joseAlgorithm)
 			.rotationInterval(definition.getRotationInterval())
 			.nextRotationTime(definition.getNextRotationTime())
 			.build();
@@ -126,10 +129,12 @@ public class JoseKeysetFactory implements KeysetFactory {
 			}
 		}
 
+		final JoseAlgorithm algorithm = (JoseAlgorithm) registry.resolve(encryptedKeyset.getAlgorithm());
+
 		return JsonWebKeyset.builder(keys)
 			.keyEncryptionKey(kek)
 			.name(encryptedKeyset.getName())
-			.algorithm(JoseAlgorithm.valueOf(encryptedKeyset.getAlgorithm()))
+			.algorithm(algorithm)
 			.rotationInterval(encryptedKeyset.getRotationInterval())
 			.nextRotationTime(encryptedKeyset.getNextRotationTime())
 			.build();

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseUtils.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseUtils.java
@@ -1,50 +1,29 @@
 package com.konfigyr.crypto.jose;
 
-import com.konfigyr.crypto.CryptoException;
 import com.konfigyr.crypto.KeyType;
-import com.konfigyr.crypto.KeysetDefinition;
-import com.konfigyr.crypto.KeysetOperation;
-import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.JWK;
+import com.konfigyr.crypto.KeysetPurpose;
 import com.nimbusds.jose.jwk.KeyOperation;
 import com.nimbusds.jose.jwk.KeyUse;
-import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import com.nimbusds.jose.jwk.gen.JWKGenerator;
-import com.nimbusds.jose.jwk.gen.OctetSequenceKeyGenerator;
-import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
-import org.springframework.util.Assert;
 
-import java.time.Instant;
-import java.util.Date;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 final class JoseUtils {
 
-	static JWKGenerator<? extends JWK> generatorForDefinition(KeysetDefinition definition) {
-		Assert.isInstanceOf(JoseAlgorithm.class, definition.getAlgorithm());
-
-		final JoseAlgorithm algorithm = (JoseAlgorithm) definition.getAlgorithm();
-
-		final JWKGenerator<?> generator =  switch (algorithm.type()) {
-			case RSA -> rsaKeyGenerator(algorithm);
-			case EC -> ecKeyGenerator(algorithm);
-			case OCTET -> octetKeyGenerator(algorithm);
+	static KeyUse resolveKeyUse(KeysetPurpose purpose) {
+		return switch (purpose) {
+			case SIGNING -> KeyUse.SIGNATURE;
+			case ENCRYPTION -> KeyUse.ENCRYPTION;
 		};
+	}
 
-		if (generator == null) {
-			throw new CryptoException.UnsupportedAlgorithmException(algorithm);
-		}
-
-		final long epochSeconds = System.currentTimeMillis() / 1000;
-
-		return generator
-			.keyID(UUID.randomUUID().toString())
-			.algorithm(algorithm.algorithm())
-			.keyUse(resolveKeyUse(algorithm))
-			.keyOperations(resolveKeyOperations(algorithm))
-			.notBeforeTime(Date.from(Instant.ofEpochSecond(epochSeconds)));
+	static Set<KeyOperation> resolveKeyOperations(KeysetPurpose purpose) {
+		return purpose.operations().stream().map(operation -> switch (operation) {
+			case SIGN -> KeyOperation.SIGN;
+			case VERIFY -> KeyOperation.VERIFY;
+			case ENCRYPT -> KeyOperation.ENCRYPT;
+			case DECRYPT -> KeyOperation.DECRYPT;
+		}).collect(Collectors.toUnmodifiableSet());
 	}
 
 	static KeyType resolveKeyType(com.nimbusds.jose.jwk.KeyType type) {
@@ -57,53 +36,6 @@ final class JoseUtils {
 		} else {
 			throw new IllegalArgumentException("Unsupported JWK key type: " + type);
 		}
-	}
-
-	private static RSAKeyGenerator rsaKeyGenerator(JoseAlgorithm algorithm) {
-		return switch (algorithm) {
-			case RS512, PS512 -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS * 2, false);
-			default -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS, false);
-		};
-	}
-
-	private static ECKeyGenerator ecKeyGenerator(JoseAlgorithm algorithm) {
-		return switch (algorithm) {
-			case ES384 -> new ECKeyGenerator(Curve.P_384);
-			case ES512 -> new ECKeyGenerator(Curve.P_521);
-			default-> new ECKeyGenerator(Curve.P_256);
-		};
-	}
-
-	private static OctetSequenceKeyGenerator octetKeyGenerator(JoseAlgorithm algorithm) {
-		return switch (algorithm) {
-			case A128KW, A128GCMKW -> new OctetSequenceKeyGenerator(128);
-			case A192KW, A192GCMKW -> new OctetSequenceKeyGenerator(192);
-			case A256KW, A256GCMKW, HS256 -> new OctetSequenceKeyGenerator(256);
-			case HS384 -> new OctetSequenceKeyGenerator(384);
-			case HS512 -> new OctetSequenceKeyGenerator(512);
-			default -> null;
-		};
-	}
-
-	private static KeyUse resolveKeyUse(JoseAlgorithm algorithm) {
-		if (algorithm.supports(KeysetOperation.SIGN) || algorithm.supports(KeysetOperation.VERIFY)) {
-			return KeyUse.SIGNATURE;
-		}
-
-		if (algorithm.supports(KeysetOperation.ENCRYPT) || algorithm.supports(KeysetOperation.DECRYPT)) {
-			return KeyUse.ENCRYPTION;
-		}
-
-		throw new IllegalStateException("Could not resolve JWK usage for algorithm: " + algorithm);
-	}
-
-	private static Set<KeyOperation> resolveKeyOperations(JoseAlgorithm algorithm) {
-		return algorithm.operations().stream().map(operation -> switch (operation) {
-			case SIGN -> KeyOperation.SIGN;
-			case VERIFY -> KeyOperation.VERIFY;
-			case ENCRYPT -> KeyOperation.ENCRYPT;
-			case DECRYPT -> KeyOperation.DECRYPT;
-		}).collect(Collectors.toUnmodifiableSet());
 	}
 
 }

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JsonWebKeyset.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JsonWebKeyset.java
@@ -9,7 +9,6 @@ import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory;
 import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory;
 import com.nimbusds.jose.jwk.*;
 import com.nimbusds.jose.jwk.KeyType;
-import com.nimbusds.jose.jwk.gen.JWKGenerator;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.*;
 import com.nimbusds.jose.produce.JWSSignerFactory;
@@ -77,7 +76,6 @@ class JsonWebKeyset implements Keyset, JWKSource<SecurityContext> {
 			).keyID(key.getKeyID()).build();
 
 			final JWEObject object = new JWEObject(header, new Payload(data.array()));
-
 			object.encrypt(createEncrypter(key));
 
 			return ByteArray.fromString(object.serialize(), StandardCharsets.UTF_8);
@@ -141,11 +139,10 @@ class JsonWebKeyset implements Keyset, JWKSource<SecurityContext> {
 
 	@Override
 	public Keyset rotate() {
-		final JWKGenerator<?> generator = JoseUtils.generatorForDefinition(this);
 		final JWK key;
 
 		try {
-			key = generator.generate();
+			key = algorithm.generator().generate();
 		} catch (JOSEException ex) {
 			throw new CryptoException.KeysetException(this, "Failed to create JWK", ex);
 		}
@@ -171,19 +168,12 @@ class JsonWebKeyset implements Keyset, JWKSource<SecurityContext> {
 	}
 
 	private JWEEncrypter createEncrypter(JWK key) throws JOSEException {
-		if (key instanceof RSAKey rsa) {
-			return new RSAEncrypter(rsa);
-		}
-
-		if (key instanceof ECKey ec) {
-			return new ECDHEncrypter(ec);
-		}
-
-		if (key instanceof OctetSequenceKey secret) {
-			return new AESEncrypter(secret);
-		}
-
-		throw new CryptoException.UnsupportedAlgorithmException(algorithm);
+		return switch (key) {
+			case RSAKey rsa -> new RSAEncrypter(rsa);
+			case ECKey ec -> new ECDHEncrypter(ec);
+			case OctetSequenceKey secret -> new AESEncrypter(secret);
+			default -> throw new CryptoException.UnsupportedAlgorithmException(algorithm);
+		};
 	}
 
 	private JWEDecrypter createDecrypter(JWEHeader header) throws JOSEException {
@@ -240,7 +230,7 @@ class JsonWebKeyset implements Keyset, JWKSource<SecurityContext> {
 			throw new KeySourceException("Found multiple keys for JWK matcher: " + matcher);
 		}
 
-		final JWK key = keys.get(0);
+		final JWK key = keys.getFirst();
 
 		if (KeyType.RSA.equals(key.getKeyType())) {
 			return resolver.apply(key.toRSAKey());
@@ -271,23 +261,18 @@ class JsonWebKeyset implements Keyset, JWKSource<SecurityContext> {
 			.filter(operation -> operation == KeyOperation.VERIFY || operation == KeyOperation.DECRYPT)
 			.collect(Collectors.toUnmodifiableSet());
 
-		final JWK jwk;
-
-		if (key.getValue() instanceof RSAKey rsa) {
-			jwk = new RSAKey.Builder(rsa)
+		final JWK jwk = switch (key.getValue()) {
+			case RSAKey rsa -> new RSAKey.Builder(rsa)
 				.keyOperations(operations)
 				.build();
-		} else if (key.getValue() instanceof ECKey ec) {
-			jwk = new ECKey.Builder(ec)
+			case ECKey ec -> new ECKey.Builder(ec)
 				.keyOperations(operations)
 				.build();
-		} else if (key.getValue() instanceof OctetSequenceKey secret) {
-			jwk = new OctetSequenceKey.Builder(secret)
+			case OctetSequenceKey secret -> new OctetSequenceKey.Builder(secret)
 				.keyOperations(operations)
 				.build();
-		} else {
-			throw new IllegalStateException("Unsupported JWK type: " + key.getValue().getKeyType());
-		}
+			default -> throw new IllegalStateException("Unsupported JWK type: " + key.getValue().getKeyType());
+		};
 
 		return new JsonWebKey(jwk, key.getStatus(), false);
 	}

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/AbstractCryptoTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/AbstractCryptoTest.java
@@ -9,7 +9,13 @@ import java.io.IOException;
 abstract class AbstractCryptoTest {
 
 	protected KeyEncryptionKey kek = new TestingKeyEncryptionKey();
-	protected KeysetFactory factory = new JoseKeysetFactory();
+	protected KeysetFactory factory = createFactory();
+
+	private static JoseKeysetFactory createFactory() {
+		final AlgorithmRegistry registry = new SimpleAlgorithmRegistry();
+		JoseAlgorithm.DEFAULT_ALGORITHMS.forEach(registry::register);
+		return new JoseKeysetFactory(registry);
+	}
 
 	protected Keyset generate(String name, Algorithm algorithm) throws IOException {
 		return factory.create(kek, KeysetDefinition.of(name, algorithm));

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseAutoConfigurationTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseAutoConfigurationTest.java
@@ -1,5 +1,8 @@
 package com.konfigyr.crypto.jose;
 
+import com.konfigyr.crypto.AlgorithmRegistry;
+import com.konfigyr.crypto.CryptoAutoConfiguration;
+import com.konfigyr.crypto.KeyEncryptionKeyProvider;
 import com.konfigyr.crypto.KeysetFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +12,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class JoseAutoConfigurationTest {
 
@@ -16,7 +20,9 @@ class JoseAutoConfigurationTest {
 
 	@BeforeEach
 	void setup() {
-		runner = new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(JoseAutoConfiguration.class));
+		runner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(CryptoAutoConfiguration.class, JoseAutoConfiguration.class))
+			.withBean(KeyEncryptionKeyProvider.class, () -> mock(KeyEncryptionKeyProvider.class));
 	}
 
 	@Test
@@ -36,7 +42,12 @@ class JoseAutoConfigurationTest {
 	void shouldApplyConfiguration() {
 		runner.run(ctx -> assertThat(ctx).hasNotFailed()
 			.hasSingleBean(JoseAutoConfiguration.class)
-			.hasSingleBean(JoseKeysetFactory.class));
+			.hasSingleBean(JoseKeysetFactory.class)
+			.hasSingleBean(AlgorithmRegistry.class)
+			.getBean(AlgorithmRegistry.class)
+			.satisfies(registry -> assertThat(registry.algorithms())
+				.containsExactlyInAnyOrderElementsOf(JoseAlgorithm.DEFAULT_ALGORITHMS)));
+
 	}
 
 }

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseIntegrationTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseIntegrationTest.java
@@ -126,7 +126,7 @@ public class JoseIntegrationTest {
 
 	@Test
 	@Order(4)
-	@DisplayName("should read and unwrap JWE keyset from the repository")
+	@DisplayName("should read and unwrap encryption keyset from the repository")
 	void shouldReadEncryptingKeyset() {
 		final var kek = store.kek(KEK_PROVIDER, KEK_IDENTIFIER);
 

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseKeysetFactoryTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseKeysetFactoryTest.java
@@ -1,37 +1,53 @@
 package com.konfigyr.crypto.jose;
 
-import com.konfigyr.crypto.EncryptedKeyset;
-import com.konfigyr.crypto.Keyset;
-import com.konfigyr.crypto.KeysetDefinition;
+import com.konfigyr.crypto.*;
 import com.konfigyr.io.ByteArray;
 import com.nimbusds.jose.shaded.gson.JsonSyntaxException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.ParseException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 class JoseKeysetFactoryTest extends AbstractCryptoTest {
 
-	@EnumSource(JoseAlgorithm.class)
+	@MethodSource("joseAlgorithms")
 	@ParameterizedTest(name = "algorithm: {0}")
 	@DisplayName("should support every defined JOSE Algorithm")
 	void shouldSupportJoseAlgorithm(JoseAlgorithm algorithm) {
 		assertThat(factory.supports(KeysetDefinition.of("test", algorithm))).isTrue();
 	}
 
-	@EnumSource(JoseAlgorithm.class)
+	@MethodSource("joseAlgorithms")
 	@ParameterizedTest(name = "algorithm: {0}")
 	@DisplayName("should support every defined JOSE Algorithm from encrypted keyset")
 	void shouldSupportJoseAlgorithmEncryptedKeysets(JoseAlgorithm algorithm) {
 		final var keyset = EncryptedKeyset.builder(KeysetDefinition.of("test", algorithm))
 			.provider("test-provider")
 			.keyEncryptionKey("test-kek")
+			.build(ByteArray.fromString("Encrypted keyset"));
+
+		assertThat(factory.supports(keyset)).isTrue();
+	}
+
+	@MethodSource("joseAlgorithms")
+	@ParameterizedTest(name = "algorithm: {0}")
+	@DisplayName("should support encrypted keysets identified by JOSE algorithm name")
+	void shouldSupportEncryptedKeysetsWithJoseAlgorithmNames(JoseAlgorithm algorithm) {
+		final var keyset = EncryptedKeyset.builder()
+			.name("test")
+			.algorithm(algorithm.name())
+			.provider("test-provider")
+			.keyEncryptionKey("test-kek")
+			.rotationInterval(Duration.ofDays(90))
+			.nextRotationTime(Instant.now().plus(Duration.ofDays(1)))
 			.build(ByteArray.fromString("Encrypted keyset"));
 
 		assertThat(factory.supports(keyset)).isTrue();
@@ -90,6 +106,18 @@ class JoseKeysetFactoryTest extends AbstractCryptoTest {
 	}
 
 	@Test
+	@DisplayName("should fail to create keyset from unsupported definition")
+	void shouldAssertUnsupportedDefinition() {
+		final var algorithm = mock(Algorithm.class);
+		final var definition = KeysetDefinition.of("test-keyset", algorithm);
+
+		assertThatExceptionOfType(CryptoException.UnsupportedAlgorithmException.class)
+			.isThrownBy(() -> factory.create(kek, definition))
+			.withMessageContaining("Unsupported algorithm")
+			.withNoCause();
+	}
+
+	@Test
 	@DisplayName("should fail to create JOSE JSON web keyset instance due to invalid JSON data")
 	void shouldFailToCreateKeysetFromInvalidJsonData() {
 		final var encrypted = EncryptedKeyset.builder()
@@ -121,6 +149,10 @@ class JoseKeysetFactoryTest extends AbstractCryptoTest {
 			.isThrownBy(() -> factory.create(kek, encrypted))
 			.withMessageContaining("Fail to read encrypted JOSE keyset: jose-key")
 			.withCauseInstanceOf(ParseException.class);
+	}
+
+	static Stream<JoseAlgorithm> joseAlgorithms() {
+		return JoseAlgorithm.DEFAULT_ALGORITHMS.stream();
 	}
 
 }

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JsonWebKeysetTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JsonWebKeysetTest.java
@@ -63,29 +63,29 @@ class JsonWebKeysetTest extends AbstractCryptoTest {
 
 	@MethodSource("encryptionAlgorithms")
 	@ParameterizedTest(name = "using algorithm: {0}")
-	@DisplayName("should encrypt byte array and decrypt it")
+	@DisplayName("should encrypt and decrypt data using JWE encryption algorithm")
 	void shouldPerformEncryptionOperations(JoseAlgorithm algorithm) throws Exception {
 		final var data = ByteArray.fromString("data to be encrypted");
-		final var key = generate("test-rs384", algorithm);
+		final var key = generate("test-jwe", algorithm);
 
 		assertThat(key.getAlgorithm().operations())
-			.as("Keyset operations for algorithm %s myst be ENCRYPT and DECRYPT", algorithm.name())
+			.as("Keyset operations for algorithm %s must be ENCRYPT and DECRYPT", algorithm.name())
 			.containsExactlyInAnyOrder(KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT);
 
-		final var cipher = key.encrypt(data);
+		final var token = key.encrypt(data);
 
-		assertThat(cipher)
-			.as("Generated JWE must not be null")
+		assertThat(token)
+			.as("Generated JWE token must not be null")
 			.isNotNull();
 
-		final var jwe = JWEObject.parse(new String(cipher.array(), StandardCharsets.UTF_8));
+		final var jwe = JWEObject.parse(new String(token.array(), StandardCharsets.UTF_8));
 
 		assertThat(jwe.getHeader().getAlgorithm())
-			.as("JWE algorithm must match keyset algorithm")
+			.as("JWE key management algorithm must match keyset algorithm")
 			.isEqualTo(algorithm.algorithm());
 
 		assertThat(jwe.getHeader().getEncryptionMethod())
-			.as("JWE encryption algorithm must be %s", EncryptionMethod.A256GCM)
+			.as("JWE content encryption algorithm must be %s", EncryptionMethod.A256GCM)
 			.isEqualTo(EncryptionMethod.A256GCM);
 
 		assertThat(jwe.getHeader().getKeyID())
@@ -96,8 +96,8 @@ class JsonWebKeysetTest extends AbstractCryptoTest {
 			.as("JWE must contain the encrypted content")
 			.isNotNull();
 
-		assertThat(key.decrypt(cipher))
-			.as("Should decrypt encrypted data back to original")
+		assertThat(key.decrypt(token))
+			.as("Should decrypt JWE token back to original data")
 			.isEqualTo(data);
 	}
 
@@ -109,7 +109,7 @@ class JsonWebKeysetTest extends AbstractCryptoTest {
 		final var selector = new JWKSelector(
 			new JWKMatcher.Builder()
 				.algorithm(JWSAlgorithm.RS256)
-				.keyID(keyset.getKeys().get(0).getId())
+				.keyID(keyset.getKeys().getFirst().getId())
 				.build()
 		);
 
@@ -165,7 +165,7 @@ class JsonWebKeysetTest extends AbstractCryptoTest {
 			.filteredOn(Key::isPrimary, false)
 			.hasSize(1)
 			.first()
-			.returns(keyset.getKeys().get(0).getId(), Key::getId)
+			.returns(keyset.getKeys().getFirst().getId(), Key::getId)
 			.returns(false, Key::isPrimary);
 	}
 
@@ -199,8 +199,8 @@ class JsonWebKeysetTest extends AbstractCryptoTest {
 	}
 
 	@Test
-	@DisplayName("rotated keys should not be performing any encrypt operations")
-	void shouldNotRotateKeysetWithEncryptOperations() throws IOException {
+	@DisplayName("rotated keys should not be performing encrypt operations")
+	void shouldNotRotateKeysetWithEncryptionOperations() throws IOException {
 		final var keyset = generate("rotating-keyset", JoseAlgorithm.A128KW);
 
 		assertThat(keyset.getKeys())
@@ -272,26 +272,26 @@ class JsonWebKeysetTest extends AbstractCryptoTest {
 	}
 
 	@Test
-	@DisplayName("should fail to decrypt invalid JWE data")
+	@DisplayName("should fail to decrypt invalid JWE token")
 	void decryptInvalidJWE() throws IOException {
 		final var key = generate("encrypting-keyset", JoseAlgorithm.A128KW);
 
 		assertThatExceptionOfType(CryptoException.KeysetOperationException.class)
-			.isThrownBy(() -> key.decrypt(ByteArray.fromString("data to be encrypted")))
+			.isThrownBy(() -> key.decrypt(ByteArray.fromString("not a jwe token")))
 			.returns(KeysetOperation.DECRYPT, CryptoException.KeysetOperationException::attemptedOperation)
 			.withRootCauseInstanceOf(ParseException.class);
 	}
 
 	@Test
-	@DisplayName("should fail to decrypt JWE encrypted by a different keyset with same algorithm")
+	@DisplayName("should fail to decrypt JWE token encrypted by a different keyset with same algorithm")
 	void decryptJWEFromDifferentKeyset() throws IOException {
 		final var encrypting = generate("encrypting-keyset", JoseAlgorithm.A128KW);
 		final var decrypting = generate("decrypting-keyset", JoseAlgorithm.A128KW);
 
-		final var jwe = encrypting.encrypt(ByteArray.fromString("data to be encrypted"));
+		final var token = encrypting.encrypt(ByteArray.fromString("data to be encrypted"));
 
 		assertThatExceptionOfType(CryptoException.KeysetOperationException.class)
-			.isThrownBy(() -> decrypting.decrypt(jwe))
+			.isThrownBy(() -> decrypting.decrypt(token))
 			.returns(KeysetOperation.DECRYPT, CryptoException.KeysetOperationException::attemptedOperation)
 			.withRootCauseInstanceOf(KeySourceException.class)
 			.havingRootCause()
@@ -361,13 +361,13 @@ class JsonWebKeysetTest extends AbstractCryptoTest {
 	}
 
 	static Stream<Arguments> signingAlgorithms() {
-		return Arrays.stream(JoseAlgorithm.values())
+		return JoseAlgorithm.DEFAULT_ALGORITHMS.stream()
 			.filter(algorithm -> algorithm.supports(KeysetOperation.SIGN))
 			.map(Arguments::of);
 	}
 
 	static Stream<Arguments> encryptionAlgorithms() {
-		return Arrays.stream(JoseAlgorithm.values())
+		return JoseAlgorithm.DEFAULT_ALGORITHMS.stream()
 			.filter(algorithm -> algorithm.supports(KeysetOperation.ENCRYPT))
 			.map(Arguments::of);
 	}

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkAlgorithm.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkAlgorithm.java
@@ -1,163 +1,244 @@
 package com.konfigyr.crypto.tink;
 
+import com.google.crypto.tink.KeyTemplate;
+import com.google.crypto.tink.Parameters;
+import com.google.crypto.tink.aead.AesCtrHmacAeadKeyManager;
+import com.google.crypto.tink.aead.AesGcmKeyManager;
+import com.google.crypto.tink.hybrid.EciesAeadHkdfPrivateKeyManager;
+import com.google.crypto.tink.signature.EcdsaSignKeyManager;
+import com.google.crypto.tink.signature.Ed25519PrivateKeyManager;
+import com.google.crypto.tink.signature.PredefinedSignatureParameters;
+import com.google.crypto.tink.signature.RsaSsaPkcs1SignKeyManager;
+import com.google.crypto.tink.signature.RsaSsaPssSignKeyManager;
 import com.konfigyr.crypto.Algorithm;
 import com.konfigyr.crypto.KeyType;
-import com.konfigyr.crypto.KeysetOperation;
-import org.jspecify.annotations.NonNull;
+import com.konfigyr.crypto.KeysetPurpose;
+import lombok.EqualsAndHashCode;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.util.Assert;
 
-import java.util.Set;
+import java.security.GeneralSecurityException;
+import java.util.List;
 
 /**
- * Collection of {@link com.konfigyr.crypto.Algorithm algorithm} that are supported by
+ * Collection of {@link Algorithm algorithms} supported by the
  * <a href="https://developers.google.com/tink/">Google Tink</a> library.
+ * <p>
+ * All built-in constants follow NIST recommendations (FIPS 186-5, SP 800-57, SP 800-38D,
+ * SP 800-38A, SP 800-56A Rev 3). Algorithm names carry a {@code "tink:"} prefix to
+ * identify this factory family and distinguish them from algorithms provided by other modules.
+ * <p>
+ * Custom Tink-based algorithms can be created by constructing an instance directly and
+ * registering it via an {@link com.konfigyr.crypto.AlgorithmRegistrar} bean.
  *
  * @author : Vladimir Spasic
- * @since : 25.08.23, Fri
- * @see <a href="https://developers.google.com/tink/supported-key-types">Tink - Supported
- * Key Types</a>
+ * @since : 15.05.26, Fri
+ * @see <a href="https://developers.google.com/tink/supported-key-types">Tink - Supported Key Types</a>
  **/
-public enum TinkAlgorithm implements Algorithm {
+@NullMarked
+@EqualsAndHashCode(of = "name")
+public final class TinkAlgorithm implements Algorithm {
 
-	/* AES Algorithms */
-
-	/**
-	 * Algorithm that uses AES-GCM cipher with a 16 bytes long secret key and random IVs.
-	 */
-	AES128_GCM(KeyType.OCTET, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
-
-	/**
-	 * Algorithm that uses AES-GCM cipher with a 32 bytes long secret key and random IVs.
-	 */
-	AES256_GCM(KeyType.OCTET, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	/* -------------------------------------------------------------------------
+	 * AES symmetric encryption algorithms (KeysetPurpose.ENCRYPTION)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * Algorithm that uses AES cipher using EAX mode with a 16 bytes long secret key and
-	 * random nonce.
+	 * AES-GCM with a 128-bit key and random IVs. NIST SP 800-38D.
 	 */
-	AES128_EAX(KeyType.OCTET, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final TinkAlgorithm AES128_GCM = new TinkAlgorithm(
+		"tink:AES128_GCM", KeysetPurpose.ENCRYPTION, KeyType.OCTET, AesGcmKeyManager.aes128GcmTemplate()
+	);
 
 	/**
-	 * Algorithm that uses AES cipher using EAX mode with a 32 bytes long secret key and
-	 * random nonce.
+	 * AES-GCM with a 256-bit key and random IVs. NIST SP 800-38D.
 	 */
-	AES256_EAX(KeyType.OCTET, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final TinkAlgorithm AES256_GCM = new TinkAlgorithm(
+		"tink:AES256_GCM", KeysetPurpose.ENCRYPTION, KeyType.OCTET, AesGcmKeyManager.aes256GcmTemplate()
+	);
 
 	/**
-	 * Algorithm performs an encrypt-then-authenticate operation. Encryption is preformed
-	 * using the AES counter mode with a 16 bytes long secret key and HMAC-SHA message
-	 * authentication code (MAC).
+	 * AES-128 in CTR mode with HMAC-SHA256 authentication. NIST SP 800-38A + FIPS 198-1.
 	 */
-	AES128_CTR_HMAC_SHA256(KeyType.OCTET, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final TinkAlgorithm AES128_CTR_HMAC_SHA256 = new TinkAlgorithm(
+		"tink:AES128_CTR_HMAC_SHA256", KeysetPurpose.ENCRYPTION, KeyType.OCTET,
+		AesCtrHmacAeadKeyManager.aes128CtrHmacSha256Template()
+	);
 
 	/**
-	 * Algorithm performs an encrypt-then-authenticate operation. Encryption is preformed
-	 * using the AES counter mode with a 32 bytes long secret key and HMAC-SHA message
-	 * authentication code (MAC).
+	 * AES-256 in CTR mode with HMAC-SHA256 authentication. NIST SP 800-38A + FIPS 198-1.
 	 */
-	AES256_CTR_HMAC_SHA256(KeyType.OCTET, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final TinkAlgorithm AES256_CTR_HMAC_SHA256 = new TinkAlgorithm(
+		"tink:AES256_CTR_HMAC_SHA256", KeysetPurpose.ENCRYPTION, KeyType.OCTET,
+		AesCtrHmacAeadKeyManager.aes256CtrHmacSha256Template()
+	);
 
-	/* Hybrid Public Keys */
-
-	/**
-	 * Encryption algorithm using Diffie-Hellman based key encapsulation mechanism
-	 * (DH-KEM) with X25519 elliptic curve key agreement, SHA256 key derivation that would
-	 * use the {@link TinkAlgorithm#AES128_GCM} to perform AEAD encryption.
-	 */
-	DHKEM_X25519_HKDF_SHA256_HKDF_SHA256_AES_128_GCM(KeyType.EC, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	/* -------------------------------------------------------------------------
+	 * Hybrid public-key encryption algorithms (KeysetPurpose.ENCRYPTION)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * Encryption algorithm using Diffie-Hellman based key encapsulation mechanism
-	 * (DH-KEM) with X25519 elliptic curve key agreement, SHA256 key derivation that would
-	 * use the {@link TinkAlgorithm#AES256_GCM} to perform AEAD encryption.
+	 * ECIES with NIST P-256, HKDF-HMAC-SHA256, and AES-128-GCM. NIST SP 800-56A Rev 3.
 	 */
-	DHKEM_X25519_HKDF_SHA256_HKDF_SHA256_AES_256_GCM(KeyType.EC, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final TinkAlgorithm ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM = new TinkAlgorithm(
+		"tink:ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM", KeysetPurpose.ENCRYPTION, KeyType.EC,
+		EciesAeadHkdfPrivateKeyManager.eciesP256HkdfHmacSha256Aes128GcmTemplate()
+	);
 
 	/**
-	 * Encryption algorithm using Diffie-Hellman based key encapsulation mechanism
-	 * (DH-KEM) with NIST P-256 elliptic curve key agreement, SHA256 key derivation that
-	 * would use the {@link TinkAlgorithm#AES128_GCM} to perform AEAD encryption.
+	 * ECIES with NIST P-256, HKDF-HMAC-SHA256, and AES-128-CTR-HMAC-SHA256. NIST SP 800-56A Rev 3.
 	 */
-	DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM(KeyType.EC, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final TinkAlgorithm ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256 = new TinkAlgorithm(
+		"tink:ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256", KeysetPurpose.ENCRYPTION, KeyType.EC,
+		EciesAeadHkdfPrivateKeyManager.eciesP256HkdfHmacSha256Aes128CtrHmacSha256Template()
+	);
+
+	/* -------------------------------------------------------------------------
+	 * Digital signature algorithms (KeysetPurpose.SIGNING)
+	 * ---------------------------------------------------------------------- */
 
 	/**
-	 * Encryption algorithm using Diffie-Hellman based key encapsulation mechanism
-	 * (DH-KEM) NIST P-256 elliptic curve key agreement, SHA256 key derivation that would
-	 * use the {@link TinkAlgorithm#AES256_GCM} to perform AEAD encryption.
+	 * ECDSA with NIST P-256. FIPS 186-5.
 	 */
-	DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_256_GCM(KeyType.EC, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final TinkAlgorithm ECDSA_P256 = new TinkAlgorithm(
+		"tink:ECDSA_P256", KeysetPurpose.SIGNING, KeyType.EC, EcdsaSignKeyManager.ecdsaP256Template()
+	);
 
 	/**
-	 * ECIES encryption algorithm with HKDF-KEM (key encapsulation mechanism) and AEAD-DEM
-	 * (data encapsulation mechanism) using the {@link TinkAlgorithm#AES128_GCM}
-	 * algorithm.
+	 * ECDSA with NIST P-384. FIPS 186-5.
 	 */
-	ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM(KeyType.EC, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
+	public static final TinkAlgorithm ECDSA_P384 = new TinkAlgorithm(
+		"tink:ECDSA_P384", KeysetPurpose.SIGNING, KeyType.EC, PredefinedSignatureParameters.ECDSA_P384
+	);
 
 	/**
-	 * ECIES encryption algorithm with HKDF-KEM (key encapsulation mechanism) and AEAD-DEM
-	 * (data encapsulation mechanism) using the
-	 * {@link TinkAlgorithm#AES128_CTR_HMAC_SHA256} algorithm.
+	 * ECDSA with NIST P-521. FIPS 186-5.
 	 */
-	ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256(KeyType.EC, KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT),
-
-	/* Signing Algorithms */
+	public static final TinkAlgorithm ECDSA_P521 = new TinkAlgorithm(
+		"tink:ECDSA_P521", KeysetPurpose.SIGNING, KeyType.EC, PredefinedSignatureParameters.ECDSA_P521
+	);
 
 	/**
-	 * Elliptic curve signing algorithm using NIST P-256.
+	 * EdDSA with Curve25519 (Ed25519). NIST FIPS 186-5.
 	 */
-	ECDSA_P256(KeyType.EC, KeysetOperation.SIGN, KeysetOperation.VERIFY),
-	/**
-	 * Elliptic curve signing algorithm using NIST P-384.
-	 */
-	ECDSA_P384(KeyType.EC, KeysetOperation.SIGN, KeysetOperation.VERIFY),
-	/**
-	 * Elliptic curve signing algorithm using NIST P-521.
-	 */
-	ECDSA_P521(KeyType.EC, KeysetOperation.SIGN, KeysetOperation.VERIFY),
-	/**
-	 * Elliptic curve signing algorithm using EdDSA and Curve25519
-	 */
-	ED25519(KeyType.EC, KeysetOperation.SIGN, KeysetOperation.VERIFY),
-	/**
-	 * RSA signing algorithm using Probabilistic Signature Scheme (PSS) with SHA256
-	 * signature hash and 3072 RSA modulus size.
-	 */
-	RSA_SSA_PSS_3072_SHA256_SHA256_32_F4(KeyType.RSA, KeysetOperation.SIGN, KeysetOperation.VERIFY),
-	/**
-	 * RSA signing algorithm using Probabilistic Signature Scheme (PSS) with SHA512
-	 * signature hash and 4096 RSA modulus size.
-	 */
-	RSA_SSA_PSS_4096_SHA512_SHA512_64_F4(KeyType.RSA, KeysetOperation.SIGN, KeysetOperation.VERIFY),
-	/**
-	 * RSA signing algorithm using PKCS1 (RFC 3447) padding scheme with SHA256 signature
-	 * hash and 3072 RSA modulus size.
-	 */
-	RSA_SSA_PKCS1_3072_SHA256_F4(KeyType.RSA, KeysetOperation.SIGN, KeysetOperation.VERIFY),
-	/**
-	 * RSA signing algorithm using PKCS1 (RFC 3447) padding scheme with SHA512 signature
-	 * hash and 4096 RSA modulus size.
-	 */
-	RSA_SSA_PKCS1_4096_SHA512_F4(KeyType.RSA, KeysetOperation.SIGN, KeysetOperation.VERIFY);
+	public static final TinkAlgorithm ED25519 = new TinkAlgorithm(
+		"tink:ED25519", KeysetPurpose.SIGNING, KeyType.EC, Ed25519PrivateKeyManager.ed25519Template()
+	);
 
+	/**
+	 * RSA-PSS with 3072-bit key, SHA-256 hash, and public exponent F4. FIPS 186-5, SP 800-131A Rev 2.
+	 */
+	public static final TinkAlgorithm RSA_SSA_PSS_3072_SHA256_F4 = new TinkAlgorithm(
+		"tink:RSA_SSA_PSS_3072_SHA256_F4", KeysetPurpose.SIGNING, KeyType.RSA,
+		RsaSsaPssSignKeyManager.rsa3072PssSha256F4Template()
+	);
+
+	/**
+	 * RSA-PSS with 4096-bit key, SHA-512 hash, and public exponent F4. FIPS 186-5, SP 800-131A Rev 2.
+	 */
+	public static final TinkAlgorithm RSA_SSA_PSS_4096_SHA512_F4 = new TinkAlgorithm(
+		"tink:RSA_SSA_PSS_4096_SHA512_F4", KeysetPurpose.SIGNING, KeyType.RSA,
+		RsaSsaPssSignKeyManager.rsa4096PssSha512F4Template()
+	);
+
+	/**
+	 * RSA-PKCS1 with 3072-bit key, SHA-256 hash, and public exponent F4. FIPS 186-5, SP 800-131A Rev 2.
+	 */
+	public static final TinkAlgorithm RSA_SSA_PKCS1_3072_SHA256_F4 = new TinkAlgorithm(
+		"tink:RSA_SSA_PKCS1_3072_SHA256_F4", KeysetPurpose.SIGNING, KeyType.RSA,
+		RsaSsaPkcs1SignKeyManager.rsa3072SsaPkcs1Sha256F4Template()
+	);
+
+	/**
+	 * RSA-PKCS1 with 4096-bit key, SHA-512 hash, and public exponent F4. FIPS 186-5, SP 800-131A Rev 2.
+	 */
+	public static final TinkAlgorithm RSA_SSA_PKCS1_4096_SHA512_F4 = new TinkAlgorithm(
+		"tink:RSA_SSA_PKCS1_4096_SHA512_F4", KeysetPurpose.SIGNING, KeyType.RSA,
+		RsaSsaPkcs1SignKeyManager.rsa4096SsaPkcs1Sha512F4Template()
+	);
+
+	/**
+	 * List of default, built-in Tink algorithms.
+	 */
+	public static final List<TinkAlgorithm> DEFAULT_ALGORITHMS = List.of(
+		AES128_GCM, AES256_GCM, AES128_CTR_HMAC_SHA256, AES256_CTR_HMAC_SHA256,
+		ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM, ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256,
+		ECDSA_P256, ECDSA_P384, ECDSA_P521, ED25519,
+		RSA_SSA_PSS_3072_SHA256_F4, RSA_SSA_PSS_4096_SHA512_F4,
+		RSA_SSA_PKCS1_3072_SHA256_F4, RSA_SSA_PKCS1_4096_SHA512_F4
+	);
+
+	private final String name;
+	private final KeysetPurpose purpose;
 	private final KeyType type;
+	private final KeyTemplate template;
 
-	private final Set<KeysetOperation> operations;
-
-	TinkAlgorithm(KeyType type, KeysetOperation... operations) {
-		this.type = type;
-		this.operations = Set.of(operations);
+	/**
+	 * Creates a custom Tink algorithm with an explicit name, purpose, key type, and key parameters.
+	 * <p>
+	 * Use this constructor to define custom Tink-backed algorithms beyond the built-in constants.
+	 * The {@code name} must be unique across all registered algorithms and must not change once
+	 * key material has been created with this algorithm.
+	 *
+	 * @param name        unique name for the algorithm, must not be blank
+	 * @param purpose     intended cryptographic purpose, must not be {@literal null}
+	 * @param type        key material type, must not be {@literal null}
+	 * @param parameters Tink key parameters used to create the {@link KeyTemplate}, must not be {@literal null}
+	 */
+	public TinkAlgorithm(String name, KeysetPurpose purpose, KeyType type, Parameters parameters) {
+		this(name, purpose, type, keyTemplate(parameters));
 	}
 
-	@NonNull
+	/**
+	 * Creates a custom Tink algorithm with an explicit name, purpose, key type, and key template.
+	 * <p>
+	 * Use this constructor to define custom Tink-backed algorithms beyond the built-in constants.
+	 * The {@code name} must be unique across all registered algorithms and must not change once
+	 * key material has been created with this algorithm.
+	 *
+	 * @param name     unique name for the algorithm, must not be blank
+	 * @param purpose  intended cryptographic purpose, must not be {@literal null}
+	 * @param type     key material type, must not be {@literal null}
+	 * @param template Tink key template defining the key parameters, must not be {@literal null}
+	 */
+	public TinkAlgorithm(String name, KeysetPurpose purpose, KeyType type, KeyTemplate template) {
+		Assert.isTrue(name.startsWith("tink:"), "Tink algorithm names must start with 'tink:' prefix");
+		this.name = name;
+		this.purpose = purpose;
+		this.type = type;
+		this.template = template;
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public KeysetPurpose purpose() {
+		return purpose;
+	}
+
 	@Override
 	public KeyType type() {
 		return type;
 	}
 
-	@NonNull
+	KeyTemplate template() {
+		return template;
+	}
+
 	@Override
-	public Set<KeysetOperation> operations() {
-		return operations;
+	public String toString() {
+		return name;
+	}
+
+	private static KeyTemplate keyTemplate(Parameters parameters) {
+		try {
+			return KeyTemplate.createFrom(parameters);
+		} catch (GeneralSecurityException e) {
+			throw new IllegalStateException("Failed to create Tink KeyTemplate from parameters", e);
+		}
 	}
 
 }

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkAutoConfiguration.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkAutoConfiguration.java
@@ -1,5 +1,7 @@
 package com.konfigyr.crypto.tink;
 
+import com.konfigyr.crypto.AlgorithmRegistrar;
+import com.konfigyr.crypto.AlgorithmRegistry;
 import com.konfigyr.crypto.CryptoAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -20,8 +22,13 @@ import org.springframework.context.annotation.Bean;
 public class TinkAutoConfiguration {
 
 	@Bean
-	TinkKeysetFactory tinkKeysetFactory() {
-		return new TinkKeysetFactory();
+	AlgorithmRegistrar tinkAlgorithmRegistrar() {
+		return registry -> TinkAlgorithm.DEFAULT_ALGORITHMS.forEach(registry::register);
+	}
+
+	@Bean
+	TinkKeysetFactory tinkKeysetFactory(AlgorithmRegistry registry) {
+		return new TinkKeysetFactory(registry);
 	}
 
 }

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeyset.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeyset.java
@@ -214,7 +214,7 @@ class TinkKeyset implements Keyset {
 	}
 
 	private com.google.crypto.tink.proto.KeyTemplate parseKeyTemplateProto() throws GeneralSecurityException {
-		final Parameters parameters = TinkUtils.keyTemplateForAlgorithm(algorithm).toParameters();
+		final Parameters parameters = algorithm.template().toParameters();
 
 		try {
 			return com.google.crypto.tink.proto.KeyTemplate.parseFrom(TinkProtoParametersFormat.serialize(parameters));

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeysetFactory.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeysetFactory.java
@@ -3,6 +3,7 @@ package com.konfigyr.crypto.tink;
 import com.google.crypto.tink.*;
 import com.konfigyr.crypto.*;
 import com.konfigyr.io.ByteArray;
+import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.util.Assert;
 
@@ -29,31 +30,33 @@ import java.security.GeneralSecurityException;
  * @see TinkKeyset
  **/
 @NullMarked
+@RequiredArgsConstructor
 public class TinkKeysetFactory implements KeysetFactory {
+
+	private final AlgorithmRegistry registry;
 
 	@Override
 	public boolean supports(EncryptedKeyset encryptedKeyset) {
-		for (TinkAlgorithm algorithm : TinkAlgorithm.values()) {
-			if (algorithm.name().equals(encryptedKeyset.getAlgorithm())) {
-				return true;
-			}
-		}
-		return false;
+		return registry.find(encryptedKeyset.getAlgorithm())
+			.filter(a -> a instanceof TinkAlgorithm)
+			.isPresent();
 	}
 
 	@Override
 	public boolean supports(KeysetDefinition definition) {
-		return TinkUtils.isSupportedAlgorithm(definition.getAlgorithm());
+		return definition.getAlgorithm() instanceof TinkAlgorithm;
 	}
 
 	@Override
 	public Keyset create(KeyEncryptionKey kek, KeysetDefinition definition) {
-		final KeyTemplate template = TinkUtils.keyTemplateForAlgorithm(definition.getAlgorithm());
+		if (!(definition.getAlgorithm() instanceof TinkAlgorithm tinkAlgorithm)) {
+			throw new CryptoException.UnsupportedAlgorithmException(definition.getAlgorithm());
+		}
 
 		final KeysetHandle handle;
 
 		try {
-			handle = KeysetHandle.generateNew(template);
+			handle = KeysetHandle.generateNew(tinkAlgorithm.template());
 		}
 		catch (GeneralSecurityException e) {
 			throw new CryptoException.UnsupportedAlgorithmException(definition.getAlgorithm(), e);
@@ -61,7 +64,7 @@ public class TinkKeysetFactory implements KeysetFactory {
 
 		return TinkKeyset.builder(handle)
 			.name(definition.getName())
-			.algorithm((TinkAlgorithm) definition.getAlgorithm())
+			.algorithm(tinkAlgorithm)
 			.keyEncryptionKey(kek)
 			.rotationInterval(definition.getRotationInterval())
 			.nextRotationTime(definition.getNextRotationTime())
@@ -108,9 +111,11 @@ public class TinkKeysetFactory implements KeysetFactory {
 			throw new CryptoException.UnwrappingException(name, kek, e);
 		}
 
+		final TinkAlgorithm algorithm = (TinkAlgorithm) registry.resolve(encryptedKeyset.getAlgorithm());
+
 		return TinkKeyset.builder(handle)
 			.name(name)
-			.algorithm(TinkAlgorithm.valueOf(encryptedKeyset.getAlgorithm()))
+			.algorithm(algorithm)
 			.keyEncryptionKey(kek)
 			.rotationInterval(encryptedKeyset.getRotationInterval())
 			.nextRotationTime(encryptedKeyset.getNextRotationTime())

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkUtils.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkUtils.java
@@ -5,10 +5,7 @@ import com.google.crypto.tink.KeyTemplates;
 import com.google.crypto.tink.aead.AeadConfig;
 import com.google.crypto.tink.hybrid.HybridConfig;
 import com.google.crypto.tink.signature.SignatureConfig;
-import com.konfigyr.crypto.Algorithm;
-import com.konfigyr.crypto.CryptoException;
 import lombok.experimental.UtilityClass;
-import org.springframework.util.ClassUtils;
 
 import java.security.GeneralSecurityException;
 
@@ -27,23 +24,6 @@ class TinkUtils {
 		}
 		catch (GeneralSecurityException e) {
 			throw new IllegalStateException("Fail to register Tink configurations", e);
-		}
-	}
-
-	static boolean isSupportedAlgorithm(Algorithm algorithm) {
-		return ClassUtils.isAssignableValue(TinkAlgorithm.class, algorithm);
-	}
-
-	static KeyTemplate keyTemplateForAlgorithm(Algorithm algorithm) {
-		if (!isSupportedAlgorithm(algorithm)) {
-			throw new CryptoException.UnsupportedAlgorithmException(algorithm);
-		}
-
-		try {
-			return KeyTemplates.get(algorithm.name());
-		}
-		catch (GeneralSecurityException e) {
-			throw new CryptoException.UnsupportedAlgorithmException(algorithm, e);
 		}
 	}
 

--- a/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/AbstractCryptoTest.java
+++ b/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/AbstractCryptoTest.java
@@ -19,13 +19,19 @@ public abstract class AbstractCryptoTest {
 
 	public static final ByteArray CONTEXT = ByteArray.fromString("Deterministic AEAD context - Associated Data");
 
-	protected KeysetFactory factory = new TinkKeysetFactory();
+	protected KeysetFactory factory = createFactory();
 
 	protected KeyEncryptionKey kek = TinkKeyEncryptionKey.builder("test-provider").generate("test-kek");
 
 	@BeforeAll
 	protected static void register() {
 		TinkUtils.register();
+	}
+
+	private static TinkKeysetFactory createFactory() {
+		final AlgorithmRegistry registry = new SimpleAlgorithmRegistry();
+		TinkAlgorithm.DEFAULT_ALGORITHMS.forEach(registry::register);
+		return new TinkKeysetFactory(registry);
 	}
 
 	protected Keyset generate(String name, Algorithm algorithm) throws IOException {

--- a/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkAutoConfigurationTest.java
+++ b/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkAutoConfigurationTest.java
@@ -1,6 +1,6 @@
 package com.konfigyr.crypto.tink;
 
-import com.konfigyr.crypto.KeysetFactory;
+import com.konfigyr.crypto.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class TinkAutoConfigurationTest {
 
@@ -16,11 +17,13 @@ class TinkAutoConfigurationTest {
 
 	@BeforeEach
 	void setup() {
-		runner = new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(TinkAutoConfiguration.class));
+		runner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(CryptoAutoConfiguration.class, TinkAutoConfiguration.class))
+			.withBean(KeyEncryptionKeyProvider.class, () -> mock(KeyEncryptionKeyProvider.class));
 	}
 
 	@Test
-	@DisplayName("should not register the Tink keyset factory if one is already present")
+	@DisplayName("should not register the Tink autoconfiguration if keyset factory bean is already present")
 	void shouldNotApplyConfigurationDueToDeclaredFactoryBean() {
 		final var factory = Mockito.mock(TinkKeysetFactory.class);
 
@@ -36,7 +39,11 @@ class TinkAutoConfigurationTest {
 	void shouldApplyConfiguration() {
 		runner.run(ctx -> assertThat(ctx).hasNotFailed()
 			.hasSingleBean(TinkAutoConfiguration.class)
-			.hasSingleBean(TinkKeysetFactory.class));
+			.hasSingleBean(TinkKeysetFactory.class)
+			.hasSingleBean(AlgorithmRegistry.class)
+			.getBean(AlgorithmRegistry.class)
+			.satisfies(registry -> assertThat(registry.algorithms())
+				.containsExactlyInAnyOrderElementsOf(TinkAlgorithm.DEFAULT_ALGORITHMS)));
 	}
 
 }

--- a/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkIntegrationTest.java
+++ b/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkIntegrationTest.java
@@ -87,7 +87,7 @@ public class TinkIntegrationTest {
 	@Order(3)
 	@DisplayName("should wrap and write keyset in the repository")
 	void shouldWriteKeyset() throws Exception {
-		final var handle = KeysetHandle.generateNew(TinkUtils.keyTemplateForAlgorithm(TinkAlgorithm.ED25519));
+		final var handle = KeysetHandle.generateNew(TinkAlgorithm.ED25519.template());
 
 		final var keyset = TinkKeyset.builder(handle)
 			.name("singing-key")

--- a/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkKeysetFactoryTest.java
+++ b/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkKeysetFactoryTest.java
@@ -5,13 +5,14 @@ import com.konfigyr.io.ByteArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,14 +22,14 @@ import static org.mockito.Mockito.mock;
 class TinkKeysetFactoryTest extends AbstractCryptoTest {
 
 	@ParameterizedTest
-	@EnumSource(TinkAlgorithm.class)
+	@MethodSource("tinkAlgorithms")
 	@DisplayName("factory should support Tink algorithms when checking keyset definitions")
 	void shouldSupportTinkAlgorithmDefinitions(TinkAlgorithm algorithm) {
 		assertThat(factory.supports(KeysetDefinition.of("test", algorithm))).isTrue();
 	}
 
 	@ParameterizedTest
-	@EnumSource(TinkAlgorithm.class)
+	@MethodSource("tinkAlgorithms")
 	@DisplayName("factory should support Tink algorithms when checking encrypted keysets")
 	void shouldSupportTinkAlgorithmEncryptedKeysets(TinkAlgorithm algorithm) {
 		final var keyset = EncryptedKeyset.builder(KeysetDefinition.of("test", algorithm))
@@ -40,7 +41,7 @@ class TinkKeysetFactoryTest extends AbstractCryptoTest {
 	}
 
 	@ParameterizedTest
-	@EnumSource(TinkAlgorithm.class)
+	@MethodSource("tinkAlgorithms")
 	@DisplayName("factory should support Tink algorithms names")
 	void shouldSupportEncryptedKeysetsWithTinkAlgorithmNames(TinkAlgorithm algorithm) {
 		final var keyset = EncryptedKeyset.builder()
@@ -87,10 +88,10 @@ class TinkKeysetFactoryTest extends AbstractCryptoTest {
 	@Test
 	@DisplayName("should create Tink keyset")
 	void shouldCreateTinkKeyset() throws Exception {
-		assertThatObject(generate("tink-key", TinkAlgorithm.AES128_EAX)).isNotNull()
+		assertThatObject(generate("tink-key", TinkAlgorithm.AES128_GCM)).isNotNull()
 			.isInstanceOf(TinkKeyset.class)
 			.returns("tink-key", Keyset::getName)
-			.returns(TinkAlgorithm.AES128_EAX, Keyset::getAlgorithm);
+			.returns(TinkAlgorithm.AES128_GCM, Keyset::getAlgorithm);
 	}
 
 	@Test
@@ -177,7 +178,20 @@ class TinkKeysetFactoryTest extends AbstractCryptoTest {
 
 	enum TestAlgorithm implements Algorithm {
 
-		ENCRYPTION, SIGNING;
+		ENCRYPTION(KeysetPurpose.ENCRYPTION),
+		SIGNING(KeysetPurpose.SIGNING);
+
+		private final KeysetPurpose purpose;
+
+		TestAlgorithm(KeysetPurpose purpose) {
+			this.purpose = purpose;
+		}
+
+		@NonNull
+		@Override
+		public KeysetPurpose purpose() {
+			return purpose;
+		}
 
 		@NonNull
 		@Override
@@ -185,12 +199,9 @@ class TinkKeysetFactoryTest extends AbstractCryptoTest {
 			return KeyType.OCTET;
 		}
 
-		@NonNull
-		@Override
-		public Set<KeysetOperation> operations() {
-			return Set.of(KeysetOperation.ENCRYPT, KeysetOperation.DECRYPT);
-		}
-
 	}
 
+	static Stream<TinkAlgorithm> tinkAlgorithms() {
+		return TinkAlgorithm.DEFAULT_ALGORITHMS.stream();
+	}
 }

--- a/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkKeysetTest.java
+++ b/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkKeysetTest.java
@@ -50,7 +50,7 @@ class TinkKeysetTest extends AbstractCryptoTest {
 	@Test
 	@DisplayName("should perform encryption using tink HybridEncrypt primitive")
 	void shouldPerformHybridEncryptionOperation() throws Exception {
-		final var keyset = generate("test", TinkAlgorithm.DHKEM_X25519_HKDF_SHA256_HKDF_SHA256_AES_128_GCM);
+		final var keyset = generate("test", TinkAlgorithm.ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM);
 		final var cypher = keyset.encrypt(DATA);
 
 		assertThat(cypher).isNotNull();
@@ -60,7 +60,7 @@ class TinkKeysetTest extends AbstractCryptoTest {
 			.satisfies(assertOperationException("test", KeysetOperation.DECRYPT));
 
 		assertThatThrownBy(
-				() -> generate("test", TinkAlgorithm.DHKEM_X25519_HKDF_SHA256_HKDF_SHA256_AES_128_GCM).decrypt(cypher))
+				() -> generate("test", TinkAlgorithm.ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM).decrypt(cypher))
 			.satisfies(assertOperationException("test", KeysetOperation.DECRYPT));
 	}
 
@@ -116,7 +116,7 @@ class TinkKeysetTest extends AbstractCryptoTest {
 				.extracting(Key::getType, Key::getStatus, Key::isPrimary)
 				.containsExactlyInAnyOrder(tuple(KeyType.OCTET, KeyStatus.ENABLED, true),
 						tuple(KeyType.OCTET, KeyStatus.ENABLED, false)))
-			.satisfies(it -> assertThat(it.getKey(keyset.getKeys().get(0).getId())).isPresent()
+			.satisfies(it -> assertThat(it.getKey(keyset.getKeys().getFirst().getId())).isPresent()
 				.get()
 				.returns(false, Key::isPrimary));
 	}


### PR DESCRIPTION
- Introduces `AlgorithmRegistry` and `AlgorithmRegistrar` as the canonical, sealed startup-time catalog for all `Algorithm` instances. The registry prevents algorithm confusion attacks (unknown algorithm names fail fast at load time) and provides a clean extension point for custom crypto providers.
- Converts `TinkAlgorithm` and `JoseAlgorithm` from enums to immutable value classes, enabling custom algorithms to be created by instantiation rather than requiring enum membership.
- Introduces `KeysetPurpose` (`SIGNING`, `ENCRYPTION`) as the single source of truth for which operations a keyset supports. `Algorithm.purpose()` replaces the per-implementation `operations()` override pattern.
- Makes all `Keyset` crypto operations default-throwing so implementations only override what they actually support, eliminating dead throw-through stubs.