### PR TITLE
Add cryptographic key material lifecycle state machine

### DIFF
--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKeyset.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKeyset.java
@@ -103,6 +103,19 @@ public abstract class AbstractKeyset<T extends Key> implements Keyset {
 		Assert.notNull(builder.keys, "Keyset keys can't be null");
 		Assert.isTrue(!builder.keys.isEmpty(), "Keyset must have at least one key");
 
+		final T primary = builder.keys.stream()
+			.filter(Key::isPrimary)
+			.findFirst()
+			.orElseThrow(() -> new CryptoException.KeysetException(
+				builder.name, "Keyset '" + builder.name + "' must have a primary key"));
+
+		switch (primary.getStatus()) {
+			case DISABLED -> throw new CryptoException.KeysetDisabledException(builder.name);
+			case PENDING_DESTRUCTION -> throw new CryptoException.KeysetPendingDestructionException(builder.name);
+			case DESTROYED -> throw new CryptoException.KeysetDestroyedException(builder.name);
+			default -> { }
+		}
+
 		this.name = builder.name;
 		this.factory = builder.factory;
 		this.purpose = builder.purpose;

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoException.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoException.java
@@ -490,6 +490,162 @@ public abstract class CryptoException extends RuntimeException {
 	}
 
 	/**
+	 * Exception thrown when a {@link Keyset} is accessed but its primary {@link Key} is
+	 * in {@link KeyStatus#DISABLED} state and cannot perform any cryptographic operations.
+	 * <p>
+	 * This exception is thrown by the keyset construction path (e.g. {@link AbstractKeyset})
+	 * before any key material is unwrapped, ensuring no sensitive data is touched for
+	 * disabled keysets.
+	 */
+	public static class KeysetDisabledException extends KeysetException {
+
+		@Serial
+		private static final long serialVersionUID = SERIAL;
+
+		/**
+		 * Creates a new {@link KeysetDisabledException} for the given keyset name.
+		 *
+		 * @param name the name of the disabled {@link Keyset}, can't be {@literal null}
+		 */
+		public KeysetDisabledException(String name) {
+			super(name, "Keyset '" + name + "' is disabled and cannot perform cryptographic operations. "
+					+ "Enable the primary key before attempting to use this keyset.");
+		}
+
+	}
+
+	/**
+	 * Exception thrown when a {@link Keyset} is accessed but its primary {@link Key} is
+	 * in {@link KeyStatus#PENDING_DESTRUCTION} state.
+	 * <p>
+	 * A keyset in this state has been scheduled for destruction and is waiting for the
+	 * configured grace period to elapse. No cryptographic operations are permitted.
+	 * Call {@code KeysetStore.cancelDestruction} to restore the key to
+	 * {@link KeyStatus#DISABLED} if the destruction was unintended.
+	 */
+	public static class KeysetPendingDestructionException extends KeysetDisabledException {
+
+		@Serial
+		private static final long serialVersionUID = SERIAL;
+
+		/**
+		 * Creates a new {@link KeysetPendingDestructionException} for the given keyset name.
+		 *
+		 * @param name the name of the {@link Keyset} pending destruction, can't be {@literal null}
+		 */
+		public KeysetPendingDestructionException(String name) {
+			super(name);
+		}
+
+		@Override
+		public String getMessage() {
+			return "Keyset '" + getName() + "' is pending destruction and cannot perform cryptographic "
+					+ "operations. Call cancelDestruction to restore it to a disabled state.";
+		}
+
+	}
+
+	/**
+	 * Exception thrown when a {@link Keyset} is accessed but its primary {@link Key} has
+	 * been permanently destroyed ({@link KeyStatus#DESTROYED}).
+	 * <p>
+	 * A destroyed key's material has been erased and cannot be recovered. If the keyset
+	 * has no remaining {@link KeyStatus#ENABLED} key, it is permanently inoperable.
+	 */
+	public static class KeysetDestroyedException extends KeysetException {
+
+		@Serial
+		private static final long serialVersionUID = SERIAL;
+
+		/**
+		 * Creates a new {@link KeysetDestroyedException} for the given keyset name.
+		 *
+		 * @param name the name of the {@link Keyset} whose primary key has been destroyed,
+		 *             can't be {@literal null}
+		 */
+		public KeysetDestroyedException(String name) {
+			super(name, "Keyset '" + name + "' primary key has been permanently destroyed. "
+					+ "The key material cannot be recovered.");
+		}
+
+	}
+
+	/**
+	 * Exception thrown when an attempt is made to transition a {@link Key} to an invalid
+	 * {@link KeyStatus} from its current state.
+	 * <p>
+	 * For example, calling {@code scheduleDestruction} on a key that is still
+	 * {@link KeyStatus#ENABLED} (rather than {@link KeyStatus#DISABLED}) will throw this
+	 * exception because the required deactivation step was skipped.
+	 * <p>
+	 * This exception carries the keyset name, the key identifier, the current status,
+	 * and the attempted (target) status for diagnostic purposes.
+	 */
+	public static class InvalidKeyStatusTransitionException extends KeysetException {
+
+		@Serial
+		private static final long serialVersionUID = SERIAL;
+
+		/**
+		 * The identifier of the {@link Key} for which the transition was attempted.
+		 */
+		private final String keyId;
+
+		/**
+		 * The current {@link KeyStatus} of the {@link Key} when the transition was attempted.
+		 */
+		private final KeyStatus currentStatus;
+
+		/**
+		 * The {@link KeyStatus} that the caller attempted to transition the key into.
+		 */
+		private final KeyStatus attemptedStatus;
+
+		/**
+		 * Creates a new {@link InvalidKeyStatusTransitionException}.
+		 *
+		 * @param keysetName    the name of the keyset containing the key, can't be {@literal null}
+		 * @param keyId         the identifier of the key, can't be {@literal null}
+		 * @param currentStatus the current status of the key, can't be {@literal null}
+		 * @param attemptedStatus the status the caller tried to set, can't be {@literal null}
+		 */
+		public InvalidKeyStatusTransitionException(
+				String keysetName, String keyId,
+				KeyStatus currentStatus, KeyStatus attemptedStatus) {
+			super(keysetName, "Invalid key status transition for key '" + keyId + "' in keyset '"
+					+ keysetName + "': cannot transition from " + currentStatus + " to " + attemptedStatus + ".");
+			this.keyId = keyId;
+			this.currentStatus = currentStatus;
+			this.attemptedStatus = attemptedStatus;
+		}
+
+		/**
+		 * @return the identifier of the {@link Key} for which the transition was attempted,
+		 *         never {@literal null}
+		 */
+		public @NonNull String getKeyId() {
+			return keyId;
+		}
+
+		/**
+		 * @return the current {@link KeyStatus} of the key when the invalid transition was
+		 *         attempted, never {@literal null}
+		 */
+		public @NonNull KeyStatus getCurrentStatus() {
+			return currentStatus;
+		}
+
+		/**
+		 * @return the {@link KeyStatus} that was attempted but is not a valid transition from
+		 *         {@link #getCurrentStatus()}, never {@literal null}
+		 */
+		public @NonNull KeyStatus getAttemptedStatus() {
+			return attemptedStatus;
+		}
+
+	}
+
+	/**
 	 * Exception thrown when the {@link Keyset} is being encrypted, or wrapped, by the
 	 * responsible {@link KeyEncryptionKey}.
 	 * <p>

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKey.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKey.java
@@ -120,6 +120,29 @@ public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource
 	}
 
 	/**
+	 * Creates a new instance of the {@link Builder} pre-populated from an existing {@link EncryptedKey}.
+	 * <p>
+	 * All fields are copied as-is. Callers can then override individual fields (e.g. {@code status},
+	 * {@code destructionScheduledAt}) before calling {@link Builder#build(ByteArray)}.
+	 *
+	 * @param existing the source {@link EncryptedKey} to copy, can't be {@literal null}
+	 * @return a pre-populated builder, never {@literal null}
+	 */
+	public static Builder builder(EncryptedKey existing) {
+		return builder()
+			.id(existing.getId())
+			.algorithm(existing.getAlgorithm())
+			.type(existing.getType())
+			.status(existing.getStatus())
+			.primary(existing.isPrimary())
+			.createdAt(existing.getCreatedAt())
+			.initializedAt(existing.getInitializedAt())
+			.expiresAt(existing.getExpiresAt())
+			.destructionScheduledAt(existing.getDestructionScheduledAt())
+			.destroyedAt(existing.getDestroyedAt());
+	}
+
+	/**
 	 * Creates a new instance of the {@link EncryptedKey} from the given {@link Key} and encrypted
 	 * key material represented by the {@link ByteArray}.
 	 *

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKeyset.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKeyset.java
@@ -11,9 +11,7 @@ import org.springframework.util.Assert;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * Record that represents the {@link Keyset} at rest whose private key material is
@@ -87,6 +85,18 @@ public class EncryptedKeyset implements Iterable<EncryptedKey>, Serializable {
 	Duration destructionGracePeriod;
 
 	/**
+	 * Attempts to find the {@link EncryptedKey} with the given identifier.
+	 *
+	 * @param id the key identifier, can't be {@literal null}
+	 * @return the matching {@link EncryptedKey} or empty if not found
+	 */
+	public Optional<EncryptedKey> getKey(String id) {
+		return keys.stream()
+			.filter(key -> Objects.equals(key.getId(), id))
+			.findFirst();
+	}
+
+	/**
 	 * Returns the number of {@link EncryptedKey keys} in this keyset.
 	 *
 	 * @return keyset size.
@@ -122,6 +132,28 @@ public class EncryptedKeyset implements Iterable<EncryptedKey>, Serializable {
 			.factory(definition.getAlgorithm().factory())
 			.rotationInterval(definition.getRotationInterval().orElse(null))
 			.destructionGracePeriod(definition.getDestructionGracePeriod().orElse(null));
+	}
+
+	/**
+	 * Creates a new instance of the {@link EncryptedKeyset.Builder} pre-populated from an existing
+	 * {@link EncryptedKeyset}. All metadata fields are copied; the key list is left empty and must
+	 * be provided via {@link Builder#build(List)} or {@link Builder#build(EncryptedKey...)}.
+	 * <p>
+	 * Useful when reconstructing an {@link EncryptedKeyset} with a modified key list (e.g. after
+	 * a key status update) without having to re-specify all metadata fields.
+	 *
+	 * @param existing the source {@link EncryptedKeyset} to copy metadata from, can't be {@literal null}
+	 * @return a pre-populated builder, never {@literal null}
+	 */
+	public static Builder builder(EncryptedKeyset existing) {
+		return builder()
+			.name(existing.getName())
+			.purpose(KeysetPurpose.valueOf(existing.getPurpose()))
+			.factory(existing.getFactory())
+			.provider(existing.getProvider())
+			.keyEncryptionKey(existing.getKeyEncryptionKey())
+			.rotationInterval(existing.getRotationInterval())
+			.destructionGracePeriod(existing.getDestructionGracePeriod());
 	}
 
 	/**

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/InMemoryKeysetRepository.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/InMemoryKeysetRepository.java
@@ -2,6 +2,9 @@ package com.konfigyr.crypto;
 
 import org.jspecify.annotations.NullMarked;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,6 +34,33 @@ public class InMemoryKeysetRepository implements KeysetRepository {
 	@Override
 	public void remove(String name) {
 		store.remove(name);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * Scans all stored keysets and returns partial {@link EncryptedKeyset} views containing
+	 * only the keys in {@link KeyStatus#PENDING_DESTRUCTION} whose scheduled destruction time
+	 * is in the past.
+	 */
+	@Override
+	public List<EncryptedKeyset> findPendingDestruction() {
+		final Instant now = Instant.now();
+		final List<EncryptedKeyset> result = new ArrayList<>();
+		for (EncryptedKeyset keyset : store.values()) {
+			final List<EncryptedKey> pending = new ArrayList<>();
+			for (EncryptedKey key : keyset.getKeys()) {
+				if (key.getStatus() == KeyStatus.PENDING_DESTRUCTION
+						&& key.getDestructionScheduledAt() != null
+						&& !key.getDestructionScheduledAt().isAfter(now)) {
+					pending.add(key);
+				}
+			}
+			if (!pending.isEmpty()) {
+				result.add(EncryptedKeyset.builder(keyset).build(pending));
+			}
+		}
+		return result;
 	}
 
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyTransition.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyTransition.java
@@ -1,0 +1,150 @@
+package com.konfigyr.crypto;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+
+/**
+ * Immutable value object that describes a single key-version lifecycle transition within a
+ * {@link KeysetRepository}.
+ * <p>
+ * A {@code KeyTransition} carries the keyset name, key identifier, target {@link KeyStatus},
+ * and the two optional timestamps ({@link #getDestructionScheduledAt() destructionScheduledAt}
+ * and {@link #getDestroyedAt() destroyedAt}) that are set or cleared as part of the transition.
+ * <p>
+ * Instances must be created through one of the static factory methods. Each factory encodes
+ * the semantics of exactly one state-machine edge and ensures that only the timestamp fields
+ * relevant to that edge are populated, preventing callers from constructing an inconsistent
+ * combination of status and timestamps:
+ *
+ * <pre>{@code
+ * // ENABLED → DISABLED
+ * KeyTransition.disable(keysetName, keyId);
+ *
+ * // DISABLED → ENABLED
+ * KeyTransition.enable(keysetName, keyId);
+ *
+ * // DISABLED → PENDING_DESTRUCTION
+ * KeyTransition.scheduleDestruction(keysetName, keyId, destructionTime);
+ *
+ * // PENDING_DESTRUCTION → DISABLED
+ * KeyTransition.cancelDestruction(keysetName, keyId);
+ *
+ * // PENDING_DESTRUCTION → DESTROYED (key material erased)
+ * KeyTransition.destroy(keysetName, keyId, Instant.now());
+ * }</pre>
+ *
+ * @author : Vladimir Spasic
+ * @since : 22.05.26, Fri
+ * @see KeysetRepository#updateKeyStatus(KeyTransition)
+ * @see KeysetStore
+ **/
+@Value
+@NullMarked
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class KeyTransition {
+
+	/**
+	 * The name of the keyset that contains the key being transitioned.
+	 */
+	String keysetName;
+
+	/**
+	 * The identifier of the key version being transitioned.
+	 */
+	String keyId;
+
+	/**
+	 * The target {@link KeyStatus} to assign to the key version.
+	 */
+	KeyStatus status;
+
+	/**
+	 * The time at which the key is scheduled for destruction. Populated when transitioning
+	 * to {@link KeyStatus#PENDING_DESTRUCTION}; {@code null} for all other transitions.
+	 */
+	@Nullable
+	Instant destructionScheduledAt;
+
+	/**
+	 * The time at which the key material was permanently erased. Populated when transitioning
+	 * to {@link KeyStatus#DESTROYED}; {@code null} for all other transitions.
+	 */
+	@Nullable
+	Instant destroyedAt;
+
+	/**
+	 * Creates a transition that moves a key from {@link KeyStatus#ENABLED} to
+	 * {@link KeyStatus#DISABLED}.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId the identifier of the key to disable, can't be {@literal null}
+	 * @return the transition, never {@literal null}
+	 */
+	public static KeyTransition disable(String keysetName, String keyId) {
+		return new KeyTransition(keysetName, keyId, KeyStatus.DISABLED, null, null);
+	}
+
+	/**
+	 * Creates a transition that moves a key from {@link KeyStatus#DISABLED} to
+	 * {@link KeyStatus#ENABLED}.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId the identifier of the key to re-enable, can't be {@literal null}
+	 * @return the transition, never {@literal null}
+	 */
+	public static KeyTransition enable(String keysetName, String keyId) {
+		return new KeyTransition(keysetName, keyId, KeyStatus.ENABLED, null, null);
+	}
+
+	/**
+	 * Creates a transition that moves a key from {@link KeyStatus#DISABLED} to
+	 * {@link KeyStatus#PENDING_DESTRUCTION}, recording the scheduled destruction time.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId the identifier of the key to schedule for destruction, can't be {@literal null}
+	 * @param destructionScheduledAt the time at which the key should be destroyed,
+	 *                               can't be {@literal null}
+	 * @return the transition, never {@literal null}
+	 */
+	public static KeyTransition scheduleDestruction(
+			String keysetName, String keyId, Instant destructionScheduledAt) {
+		return new KeyTransition(keysetName, keyId, KeyStatus.PENDING_DESTRUCTION,
+				destructionScheduledAt, null);
+	}
+
+	/**
+	 * Creates a transition that moves a key from {@link KeyStatus#PENDING_DESTRUCTION} back to
+	 * {@link KeyStatus#DISABLED}, clearing the previously scheduled destruction time.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId the identifier of the key whose destruction should be cancelled,
+	 *              can't be {@literal null}
+	 * @return the transition, never {@literal null}
+	 */
+	public static KeyTransition cancelDestruction(String keysetName, String keyId) {
+		return new KeyTransition(keysetName, keyId, KeyStatus.DISABLED, null, null);
+	}
+
+	/**
+	 * Creates a transition that moves a key from {@link KeyStatus#PENDING_DESTRUCTION} to
+	 * {@link KeyStatus#DESTROYED}.
+	 * <p>
+	 * The key material ({@link EncryptedKey#getData()}) is erased — set to {@code null} — by
+	 * the repository when this transition is applied. The row itself is kept for audit purposes.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId the identifier of the key to destroy, can't be {@literal null}
+	 * @param destroyedAt the instant at which the key material was erased, can't be
+	 *                    {@literal null}
+	 * @return the transition, never {@literal null}
+	 */
+	public static KeyTransition destroy(String keysetName, String keyId, Instant destroyedAt) {
+		return new KeyTransition(keysetName, keyId, KeyStatus.DESTROYED, null, destroyedAt);
+	}
+
+}

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetRepository.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetRepository.java
@@ -1,8 +1,11 @@
 package com.konfigyr.crypto;
 
+import com.konfigyr.io.ByteArray;
 import org.jspecify.annotations.NullMarked;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -41,5 +44,78 @@ public interface KeysetRepository {
 	 * @throws IOException if there is an issue while removing the encrypted keyset
 	 */
 	void remove(String name) throws IOException;
+
+	/**
+	 * Applies the given {@link KeyTransition} to a single {@link EncryptedKey} within a stored
+	 * {@link EncryptedKeyset}, updating its {@link KeyStatus} and the destruction-related
+	 * timestamps carried by the transition.
+	 * <p>
+	 * When the transition targets {@link KeyStatus#DESTROYED}, implementations
+	 * <strong>must</strong> erase the encrypted key material
+	 * ({@link EncryptedKey#getData()} becomes {@literal null}).
+	 * The row itself is kept for audit purposes.
+	 * <p>
+	 * The default implementation uses a read-modify-write cycle via {@link #read(String)} and
+	 * {@link #write(EncryptedKeyset)}. Implementations that have direct database access should
+	 * override this with a targeted SQL {@code UPDATE} for better efficiency.
+	 * <p>
+	 * If no keyset exists under {@link KeyTransition#getKeysetName()}, this method returns
+	 * silently without error.
+	 *
+	 * @param transition the lifecycle transition to apply, can't be {@literal null}
+	 * @throws IOException if there is an issue while updating the key status
+	 */
+	default void updateKeyStatus(KeyTransition transition) throws IOException {
+		final Optional<EncryptedKeyset> existing = read(transition.getKeysetName());
+		if (existing.isEmpty()) {
+			return;
+		}
+		final EncryptedKeyset keyset = existing.get();
+		final List<EncryptedKey> updatedKeys = new ArrayList<>(keyset.size());
+		for (EncryptedKey key : keyset) {
+			if (key.getId().equals(transition.getKeyId())) {
+				final ByteArray data = transition.getStatus() == KeyStatus.DESTROYED ? null : key.getData();
+				updatedKeys.add(EncryptedKey.builder(key)
+					.status(transition.getStatus())
+					.destructionScheduledAt(transition.getDestructionScheduledAt())
+					.destroyedAt(transition.getDestroyedAt())
+					.build(data));
+			} else {
+				updatedKeys.add(key);
+			}
+		}
+		write(EncryptedKeyset.builder(keyset).build(updatedKeys));
+	}
+
+	/**
+	 * Returns a list of partial {@link EncryptedKeyset} objects where each contains only
+	 * the {@link EncryptedKey keys} whose {@link KeyStatus} is
+	 * {@link KeyStatus#PENDING_DESTRUCTION} and whose
+	 * {@link EncryptedKey#getDestructionScheduledAt() scheduled destruction time} is in the
+	 * past (i.e., the grace period has elapsed).
+	 * <p>
+	 * Each returned {@link EncryptedKeyset} is a <em>partial view</em> — it carries the
+	 * keyset metadata but only the eligible pending-destruction keys. Callers typically
+	 * iterate the returned keysets and call
+	 * {@link com.konfigyr.crypto.KeysetStore#destroy(String, String)} for each key:
+	 * <pre>{@code
+	 * for (EncryptedKeyset keyset : repository.findPendingDestruction()) {
+	 *     for (EncryptedKey key : keyset.getKeys()) {
+	 *         store.destroy(keyset.getName(), key.getId());
+	 *     }
+	 * }
+	 * }</pre>
+	 * <p>
+	 * The default implementation returns an empty list. Repositories that can scan all
+	 * stored keysets (e.g. {@link InMemoryKeysetRepository}) or issue an efficient query
+	 * (e.g. {@code JdbcKeysetRepository}) should override this method.
+	 *
+	 * @return list of partial {@link EncryptedKeyset} objects with only their pending-destruction
+	 *         keys, never {@literal null}
+	 * @throws IOException if there is an issue while querying for pending destruction keys
+	 */
+	default List<EncryptedKeyset> findPendingDestruction() throws IOException {
+		return List.of();
+	}
 
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetStore.java
@@ -5,6 +5,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.cache.support.NoOpCache;
 import org.springframework.util.Assert;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -212,6 +213,12 @@ public interface KeysetStore {
 
 	/**
 	 * Deletes the {@link Keyset} by the matching key name from the store.
+	 * <p>
+	 * This is an emergency or administrative hard-delete that bypasses the normal lifecycle
+	 * state machine. It removes the keyset row and all associated key rows regardless of the
+	 * current {@link KeyStatus} of any key. For a lifecycle-compliant removal, disable a key
+	 * first, then schedule it for destruction, let the grace period elapse, and call
+	 * {@link #destroy(String, String)}.
 	 *
 	 * @param name keyset name to be removed, can't be {@literal null}
 	 */
@@ -219,10 +226,121 @@ public interface KeysetStore {
 
 	/**
 	 * Deletes the {@link Keyset} from the store.
+	 * <p>
+	 * This is an emergency or administrative hard-delete that bypasses the normal lifecycle
+	 * state machine. See {@link #remove(String)} for details.
 	 *
 	 * @param keyset keyset to be removed, can't be {@literal null}
 	 */
 	void remove(Keyset keyset);
+
+	/**
+	 * Transitions the specified {@link Key} within the named {@link Keyset} from
+	 * {@link KeyStatus#ENABLED} to {@link KeyStatus#DISABLED}.
+	 * <p>
+	 * A disabled key cannot perform any cryptographic operations. It may subsequently be
+	 * re-enabled via {@link #enable(String, String)} or scheduled for destruction via
+	 * {@link #scheduleDestruction(String, String)}.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId      the identifier of the key to disable, can't be {@literal null}
+	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
+	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
+	 *         in {@link KeyStatus#ENABLED} state
+	 */
+	void disable(String keysetName, String keyId);
+
+	/**
+	 * Transitions the specified {@link Key} within the named {@link Keyset} from
+	 * {@link KeyStatus#DISABLED} back to {@link KeyStatus#ENABLED}.
+	 * <p>
+	 * Re-enabling a key makes it eligible to be promoted to primary for active cryptographic
+	 * operations on the next rotation.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId      the identifier of the key to enable, can't be {@literal null}
+	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
+	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
+	 *         in {@link KeyStatus#DISABLED} state
+	 */
+	void enable(String keysetName, String keyId);
+
+	/**
+	 * Transitions the specified {@link Key} within the named {@link Keyset} from
+	 * {@link KeyStatus#DISABLED} to {@link KeyStatus#PENDING_DESTRUCTION}, using the keyset's
+	 * configured {@link Keyset#getDestructionGracePeriod() destruction grace period} to compute
+	 * the scheduled destruction time.
+	 * <p>
+	 * Requires the key to be in {@link KeyStatus#DISABLED} state first (two-step deactivation
+	 * before destruction, per NIST SP 800-57 §8.3.1).
+	 * <p>
+	 * When the keyset has no destruction grace period configured ({@literal null}), the key
+	 * material is destroyed immediately: the key is transitioned through
+	 * {@link KeyStatus#PENDING_DESTRUCTION} and then straight to {@link KeyStatus#DESTROYED}
+	 * within the same call, erasing its encrypted material. This is NIST-compliant — the
+	 * standard does not mandate a minimum grace-period duration; it only requires deactivation
+	 * before destruction.
+	 * <p>
+	 * To supply an explicit target time, use {@link #scheduleDestruction(String, String, Instant)}.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId      the identifier of the key to schedule for destruction, can't be {@literal null}
+	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
+	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
+	 *         in {@link KeyStatus#DISABLED} state
+	 */
+	void scheduleDestruction(String keysetName, String keyId);
+
+	/**
+	 * Transitions the specified {@link Key} within the named {@link Keyset} from
+	 * {@link KeyStatus#DISABLED} to {@link KeyStatus#PENDING_DESTRUCTION}, with an explicit
+	 * scheduled destruction time.
+	 * <p>
+	 * Requires the key to be in {@link KeyStatus#DISABLED} state first (two-step deactivation
+	 * before destruction, per NIST SP 800-57 §8.3.1).
+	 *
+	 * @param keysetName      the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId           the identifier of the key to schedule for destruction, can't be {@literal null}
+	 * @param destructionTime the time at which destruction should occur, can't be {@literal null}
+	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
+	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
+	 *         in {@link KeyStatus#DISABLED} state
+	 */
+	void scheduleDestruction(String keysetName, String keyId, Instant destructionTime);
+
+	/**
+	 * Transitions the specified {@link Key} within the named {@link Keyset} from
+	 * {@link KeyStatus#PENDING_DESTRUCTION} back to {@link KeyStatus#DISABLED}.
+	 * <p>
+	 * Cancels a previously scheduled destruction. The key is returned to the disabled state
+	 * (never directly back to enabled), preserving the requirement that re-enabling requires
+	 * an explicit administrative decision.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId      the identifier of the key whose destruction to cancel, can't be {@literal null}
+	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
+	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
+	 *         in {@link KeyStatus#PENDING_DESTRUCTION} state
+	 */
+	void cancelDestruction(String keysetName, String keyId);
+
+	/**
+	 * Permanently destroys the specified {@link Key} within the named {@link Keyset} by erasing
+	 * its encrypted key material and transitioning it to {@link KeyStatus#DESTROYED}.
+	 * <p>
+	 * The key row is retained for audit purposes but its {@link EncryptedKey#getData() data} is
+	 * set to {@literal null} and can never be recovered. This is a soft-delete of the key material.
+	 * <p>
+	 * Requires the key to be in {@link KeyStatus#PENDING_DESTRUCTION} state. To destroy without
+	 * going through the lifecycle, use the emergency {@link #remove(String)} instead.
+	 *
+	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
+	 * @param keyId      the identifier of the key to destroy, can't be {@literal null}
+	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
+	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
+	 *         in {@link KeyStatus#PENDING_DESTRUCTION} state
+	 */
+	void destroy(String keysetName, String keyId);
 
 	/**
 	 * Builder class used to create {@link KeysetStore} instances. This builder would return an instance of

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepostoryKeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepostoryKeysetStore.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -140,6 +142,79 @@ public class RepostoryKeysetStore implements KeysetStore {
 	@Override
 	public void remove(Keyset keyset) {
 		remove(keyset.getName());
+	}
+
+	@Override
+	public void disable(String keysetName, String keyId) {
+		performKeyTransition(KeyTransition.disable(keysetName, keyId), KeyStatus.ENABLED);
+	}
+
+	@Override
+	public void enable(String keysetName, String keyId) {
+		performKeyTransition(KeyTransition.enable(keysetName, keyId), KeyStatus.DISABLED);
+	}
+
+	@Override
+	public void scheduleDestruction(String keysetName, String keyId) {
+		final EncryptedKeyset encryptedKeyset = lookupKeyset(keysetName);
+		final Duration gracePeriod = encryptedKeyset.getDestructionGracePeriod();
+		if (gracePeriod == null) {
+			scheduleDestruction(keysetName, keyId, Instant.now());
+			destroy(keysetName, keyId);
+		} else {
+			scheduleDestruction(keysetName, keyId, Instant.now().plus(gracePeriod));
+		}
+	}
+
+	@Override
+	public void scheduleDestruction(String keysetName, String keyId, Instant destructionTime) {
+		performKeyTransition(KeyTransition.scheduleDestruction(keysetName, keyId, destructionTime),
+				KeyStatus.DISABLED);
+	}
+
+	@Override
+	public void cancelDestruction(String keysetName, String keyId) {
+		performKeyTransition(KeyTransition.cancelDestruction(keysetName, keyId),
+				KeyStatus.PENDING_DESTRUCTION);
+	}
+
+	@Override
+	public void destroy(String keysetName, String keyId) {
+		performKeyTransition(KeyTransition.destroy(keysetName, keyId, Instant.now()),
+				KeyStatus.PENDING_DESTRUCTION);
+	}
+
+	/**
+	 * Looks up the key within the keyset, validates the status transition, delegates to the
+	 * repository, and evicts the cache entry.
+	 */
+	private void performKeyTransition(KeyTransition transition, KeyStatus expected) {
+		final String keysetName = transition.getKeysetName();
+		final String keyId = transition.getKeyId();
+
+		final EncryptedKeyset encryptedKeyset = lookupKeyset(keysetName);
+		final EncryptedKey key = encryptedKeyset.getKey(keyId).orElseThrow(
+			() -> new KeysetException(keysetName, "Key '" + keyId + "' was not found in keyset '" + keysetName + "'.")
+		);
+
+		if (key.getStatus() != expected) {
+			throw new InvalidKeyStatusTransitionException(keysetName, keyId, key.getStatus(),
+					transition.getStatus());
+		}
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Transitioning key '{}' in keyset '{}' from {} to {}", keyId, keysetName,
+					expected, transition.getStatus());
+		}
+
+		try {
+			repository.updateKeyStatus(transition);
+		} catch (IOException e) {
+			throw new KeysetException(keysetName,
+				"Could not update status of key '" + keyId + "' in keyset '" + keysetName + "'.", e);
+		}
+
+		cache.evict(keysetName);
 	}
 
 	/**

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/AbstractKeysetTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/AbstractKeysetTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
@@ -22,10 +21,14 @@ class AbstractKeysetTest {
 	static final Instant now = Instant.parse("2026-01-01T00:00:00Z");
 
 	static AbstractKeyTest.ConcreteKey createKey(String id, boolean primary) {
+		return createKey(id, primary, KeyStatus.ENABLED);
+	}
+
+	static AbstractKeyTest.ConcreteKey createKey(String id, boolean primary, KeyStatus status) {
 		return AbstractKeyTest.ConcreteKey.builder()
 			.id(id)
 			.algorithm(TestAlgorithm.INSTANCE)
-			.status(KeyStatus.ENABLED)
+			.status(status)
 			.primary(primary)
 			.createdAt(now)
 			.build();
@@ -164,15 +167,58 @@ class AbstractKeysetTest {
 	@Test
 	@DisplayName("should throw when no primary key is present in the keyset")
 	void shouldThrowWhenNoPrimaryKeyPresent() {
-		final var keyset = ConcreteKeyset.builder()
-			.name("test-keyset")
-			.factory("test-factory")
-			.purpose(KeysetPurpose.ENCRYPTION)
-			.keyEncryptionKey(kek)
-			.key(createKey("non-primary-key", false))
-			.build();
+		assertThatExceptionOfType(CryptoException.KeysetException.class)
+			.isThrownBy(() -> ConcreteKeyset.builder()
+				.name("test-keyset")
+				.factory("test-factory")
+				.purpose(KeysetPurpose.ENCRYPTION)
+				.keyEncryptionKey(kek)
+				.key(createKey("non-primary-key", false))
+				.build())
+			.withMessageContaining("must have a primary key")
+			.returns("test-keyset", CryptoException.KeysetException::getName);
+	}
 
-		assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(keyset::getPrimary);
+	@Test
+	@DisplayName("should throw KeysetDisabledException when the primary key is disabled")
+	void shouldThrowWhenPrimaryKeyIsDisabled() {
+		assertThatExceptionOfType(CryptoException.KeysetDisabledException.class)
+			.isThrownBy(() -> ConcreteKeyset.builder()
+				.name("test-keyset")
+				.factory("test-factory")
+				.purpose(KeysetPurpose.ENCRYPTION)
+				.keyEncryptionKey(kek)
+				.key(createKey("primary-key", true, KeyStatus.DISABLED))
+				.build())
+			.returns("test-keyset", CryptoException.KeysetException::getName);
+	}
+
+	@Test
+	@DisplayName("should throw KeysetPendingDestructionException when the primary key is pending destruction")
+	void shouldThrowWhenPrimaryKeyIsPendingDestruction() {
+		assertThatExceptionOfType(CryptoException.KeysetPendingDestructionException.class)
+			.isThrownBy(() -> ConcreteKeyset.builder()
+				.name("test-keyset")
+				.factory("test-factory")
+				.purpose(KeysetPurpose.ENCRYPTION)
+				.keyEncryptionKey(kek)
+				.key(createKey("primary-key", true, KeyStatus.PENDING_DESTRUCTION))
+				.build())
+			.returns("test-keyset", CryptoException.KeysetException::getName);
+	}
+
+	@Test
+	@DisplayName("should throw KeysetDestroyedException when the primary key has been destroyed")
+	void shouldThrowWhenPrimaryKeyIsDestroyed() {
+		assertThatExceptionOfType(CryptoException.KeysetDestroyedException.class)
+			.isThrownBy(() -> ConcreteKeyset.builder()
+				.name("test-keyset")
+				.factory("test-factory")
+				.purpose(KeysetPurpose.ENCRYPTION)
+				.keyEncryptionKey(kek)
+				.key(createKey("primary-key", true, KeyStatus.DESTROYED))
+				.build())
+			.returns("test-keyset", CryptoException.KeysetException::getName);
 	}
 
 	@Test

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeyTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeyTest.java
@@ -48,6 +48,26 @@ class EncryptedKeyTest {
 	}
 
 	@Test
+	@DisplayName("should copy all fields using the builder copy constructor")
+	void shouldCopyAllFieldsUsingBuilderCopyConstructor() {
+		final var original = EncryptedKey.builder()
+			.id("key-id")
+			.algorithm(algorithm)
+			.status(KeyStatus.ENABLED)
+			.primary(true)
+			.createdAt(now)
+			.initializedAt(now)
+			.expiresAt(now.plusSeconds(3600))
+			.destructionScheduledAt(now.plusSeconds(7200))
+			.destroyedAt(null)
+			.build(data);
+
+		final var copy = EncryptedKey.builder(original).build(original.getData());
+
+		assertThat(copy).isEqualTo(original);
+	}
+
+	@Test
 	@DisplayName("should build an encrypted key with null data for a destroyed key")
 	void shouldBuildEncryptedKeyWithNullData() {
 		final var key = EncryptedKey.builder()

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeysetTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeysetTest.java
@@ -57,6 +57,24 @@ class EncryptedKeysetTest {
 	}
 
 	@Test
+	@DisplayName("should copy all metadata fields using the builder copy constructor")
+	void shouldCopyAllFieldsUsingBuilderCopyConstructor() {
+		final var original = EncryptedKeyset.builder()
+			.name("test-keyset")
+			.purpose(KeysetPurpose.ENCRYPTION)
+			.factory("test-factory")
+			.provider("test-provider")
+			.keyEncryptionKey("test-kek")
+			.rotationInterval(Duration.ofDays(90))
+			.destructionGracePeriod(Duration.ofDays(30))
+			.build(List.of(key));
+
+		final var copy = EncryptedKeyset.builder(original).build(original.getKeys());
+
+		assertThat(copy).isEqualTo(original);
+	}
+
+	@Test
 	@DisplayName("should build an encrypted keyset with rotation and grace period disabled")
 	void shouldBuildEncryptedKeysetWithDisabledOptionals() {
 		final var keyset = EncryptedKeyset.builder()

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/InMemoryKeysetRepositoryTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/InMemoryKeysetRepositoryTest.java
@@ -1,44 +1,176 @@
 package com.konfigyr.crypto;
 
+import com.konfigyr.crypto.test.TestAlgorithm;
+import com.konfigyr.io.ByteArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.mockito.Mockito.doReturn;
 
-@ExtendWith(MockitoExtension.class)
 class InMemoryKeysetRepositoryTest {
 
-	@Mock
-	EncryptedKeyset keyset;
+	static final Instant NOW = Instant.parse("2026-01-01T00:00:00Z");
 
 	KeysetRepository repository = new InMemoryKeysetRepository();
 
 	@Test
 	@DisplayName("should manage encrypted keysets in memory")
 	void shouldManageEncryptionKeysets() throws IOException {
-		doReturn("test-keyset").when(keyset).getName();
+		final EncryptedKeyset keyset = encryptedKeyset("test-keyset",
+			encryptedKey("key-1", KeyStatus.ENABLED, true, ByteArray.fromString("key-material"), null));
 
-		assertThat(repository.read(keyset.getName()))
-			.isEmpty();
+		assertThat(repository.read(keyset.getName())).isEmpty();
 
-		assertThatNoException()
-			.isThrownBy(() -> repository.write(keyset));
+		assertThatNoException().isThrownBy(() -> repository.write(keyset));
+		assertThat(repository.read(keyset.getName())).hasValue(keyset);
 
-		assertThat(repository.read(keyset.getName()))
-			.hasValue(keyset);
+		assertThatNoException().isThrownBy(() -> repository.remove(keyset.getName()));
+		assertThat(repository.read(keyset.getName())).isEmpty();
+	}
 
-		assertThatNoException()
-			.isThrownBy(() -> repository.remove(keyset.getName()));
+	@Test
+	@DisplayName("should update key status using the default read-modify-write")
+	void shouldUpdateKeyStatus() throws IOException {
+		final EncryptedKey key = encryptedKey("key-1", KeyStatus.ENABLED, true,
+			ByteArray.fromString("key-material"), null);
+		repository.write(encryptedKeyset("test-keyset", key));
 
-		assertThat(repository.read(keyset.getName()))
-			.isEmpty();
+		assertThatNoException().isThrownBy(() ->
+			repository.updateKeyStatus(KeyTransition.disable("test-keyset", "key-1")));
+
+		assertThat(repository.read("test-keyset"))
+			.isPresent()
+			.hasValueSatisfying(ks ->
+				assertThat(ks.getKey("key-1"))
+					.isPresent()
+					.hasValueSatisfying(k -> {
+						assertThat(k.getStatus()).isEqualTo(KeyStatus.DISABLED);
+						assertThat(k.getData()).isNotNull();
+					})
+			);
+	}
+
+	@Test
+	@DisplayName("should erase key data when transitioning to DESTROYED status")
+	void shouldEraseKeyDataOnDestruction() throws IOException {
+		final Instant scheduledAt = NOW.minus(Duration.ofDays(1));
+		final EncryptedKey key = encryptedKey("key-1", KeyStatus.PENDING_DESTRUCTION, true,
+			ByteArray.fromString("key-material"), scheduledAt);
+		repository.write(encryptedKeyset("test-keyset", key));
+
+		final Instant destroyedAt = NOW;
+		assertThatNoException().isThrownBy(() ->
+			repository.updateKeyStatus(KeyTransition.destroy("test-keyset", "key-1", destroyedAt)));
+
+		assertThat(repository.read("test-keyset"))
+			.isPresent()
+			.hasValueSatisfying(ks ->
+				assertThat(ks.getKey("key-1"))
+					.isPresent()
+					.hasValueSatisfying(k -> {
+						assertThat(k.getStatus()).isEqualTo(KeyStatus.DESTROYED);
+						assertThat(k.getData()).isNull();
+						assertThat(k.getDestroyedAt()).isEqualTo(destroyedAt);
+					})
+			);
+	}
+
+	@Test
+	@DisplayName("should set destruction timestamp when scheduling a key for destruction")
+	void shouldSetDestructionScheduledAtOnPendingDestruction() throws IOException {
+		final EncryptedKey key = encryptedKey("key-1", KeyStatus.DISABLED, true,
+			ByteArray.fromString("key-material"), null);
+		repository.write(encryptedKeyset("test-keyset", key));
+
+		final Instant scheduledAt = NOW.plus(Duration.ofDays(30));
+		assertThatNoException().isThrownBy(() ->
+			repository.updateKeyStatus(KeyTransition.scheduleDestruction("test-keyset", "key-1", scheduledAt)));
+
+		assertThat(repository.read("test-keyset"))
+			.isPresent()
+			.hasValueSatisfying(ks ->
+				assertThat(ks.getKey("key-1"))
+					.isPresent()
+					.hasValueSatisfying(k -> {
+						assertThat(k.getStatus()).isEqualTo(KeyStatus.PENDING_DESTRUCTION);
+						assertThat(k.getDestructionScheduledAt()).isEqualTo(scheduledAt);
+					})
+			);
+	}
+
+	@Test
+	@DisplayName("should return keys pending destruction with an elapsed schedule")
+	void shouldFindKeysPendingDestruction() throws IOException {
+		final Instant pastSchedule = NOW.minus(Duration.ofHours(1));
+		final EncryptedKey pendingKey = encryptedKey("key-1", KeyStatus.PENDING_DESTRUCTION, true,
+			ByteArray.fromString("key-material"), pastSchedule);
+		repository.write(encryptedKeyset("test-keyset", pendingKey));
+
+		final List<EncryptedKeyset> results = repository.findPendingDestruction();
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().getName()).isEqualTo("test-keyset");
+		assertThat(results.getFirst().getKeys()).hasSize(1);
+		assertThat(results.getFirst().getKeys().getFirst().getId()).isEqualTo("key-1");
+	}
+
+	@Test
+	@DisplayName("should not return keys whose destruction schedule is in the future")
+	void shouldNotFindFutureScheduledDestructionKeys() throws IOException {
+		final Instant futureSchedule = Instant.now().plus(Duration.ofDays(7));
+		final EncryptedKey futureKey = encryptedKey("key-1", KeyStatus.PENDING_DESTRUCTION, true,
+			ByteArray.fromString("key-material"), futureSchedule);
+		repository.write(encryptedKeyset("test-keyset", futureKey));
+
+		assertThat(repository.findPendingDestruction()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should not return ENABLED keys from findPendingDestruction")
+	void shouldNotFindEnabledKeys() throws IOException {
+		final EncryptedKey enabledKey = encryptedKey("key-1", KeyStatus.ENABLED, true,
+			ByteArray.fromString("key-material"), null);
+		repository.write(encryptedKeyset("test-keyset", enabledKey));
+
+		assertThat(repository.findPendingDestruction()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should silently skip updateKeyStatus when the keyset does not exist")
+	void shouldSkipUpdateForMissingKeyset() {
+		assertThatNoException().isThrownBy(() ->
+			repository.updateKeyStatus(KeyTransition.disable("missing-keyset", "key-1")));
+	}
+
+	private static EncryptedKeyset encryptedKeyset(String name, EncryptedKey... keys) {
+		return EncryptedKeyset.builder()
+			.name(name)
+			.purpose(KeysetPurpose.ENCRYPTION)
+			.factory(TestAlgorithm.INSTANCE.factory())
+			.provider("test-provider")
+			.keyEncryptionKey("test-kek")
+			.rotationInterval(Duration.ofDays(90))
+			.destructionGracePeriod(Duration.ofDays(30))
+			.build(keys);
+	}
+
+	private static EncryptedKey encryptedKey(
+			String id, KeyStatus status, boolean primary,
+			ByteArray data, Instant destructionScheduledAt) {
+		return EncryptedKey.builder()
+			.id(id)
+			.algorithm(TestAlgorithm.INSTANCE)
+			.status(status)
+			.primary(primary)
+			.createdAt(NOW)
+			.destructionScheduledAt(destructionScheduledAt)
+			.build(data);
 	}
 
 }

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepostoryKeysetStoreTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepostoryKeysetStoreTest.java
@@ -6,16 +6,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 
+import com.konfigyr.io.ByteArray;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -419,6 +423,179 @@ class RepostoryKeysetStoreTest {
 			.returns(definition.getName(), CryptoException.KeysetException::getName);
 
 		verify(repository).remove(definition.getName());
+	}
+
+	@Test
+	@DisplayName("should disable an ENABLED key and evict the cache")
+	void shouldDisableKey() throws IOException {
+		repository.write(keysetWith("key-1", KeyStatus.ENABLED));
+
+		assertThatNoException().isThrownBy(() -> store.disable(definition.getName(), "key-1"));
+
+		verify(repository).updateKeyStatus(KeyTransition.disable(definition.getName(), "key-1"));
+		verify(cache).evict(definition.getName());
+	}
+
+	@Test
+	@DisplayName("should re-enable a DISABLED key and evict the cache")
+	void shouldEnableKey() throws IOException {
+		repository.write(keysetWith("key-1", KeyStatus.DISABLED));
+
+		assertThatNoException().isThrownBy(() -> store.enable(definition.getName(), "key-1"));
+
+		verify(repository).updateKeyStatus(KeyTransition.enable(definition.getName(), "key-1"));
+		verify(cache).evict(definition.getName());
+	}
+
+	@Test
+	@DisplayName("should schedule destruction for a DISABLED key at an explicit time")
+	void shouldScheduleDestructionAtExplicitTime() throws IOException {
+		repository.write(keysetWith("key-1", KeyStatus.DISABLED));
+
+		final Instant destructionTime = Instant.now().plus(Duration.ofDays(30));
+		assertThatNoException().isThrownBy(
+			() -> store.scheduleDestruction(definition.getName(), "key-1", destructionTime));
+
+		verify(repository).updateKeyStatus(
+			KeyTransition.scheduleDestruction(definition.getName(), "key-1", destructionTime));
+		verify(cache).evict(definition.getName());
+	}
+
+	@Test
+	@DisplayName("should schedule destruction using the keyset grace period")
+	void shouldScheduleDestructionUsingGracePeriod() throws IOException {
+		final Duration grace = Duration.ofDays(30);
+		final EncryptedKeyset keysetWithGrace = EncryptedKeyset.builder(definition)
+			.provider(kek.getProvider())
+			.keyEncryptionKey(kek.getId())
+			.destructionGracePeriod(grace)
+			.build(List.of(encryptedKey("key-1", KeyStatus.DISABLED)));
+
+		repository.write(keysetWithGrace);
+
+		assertThatNoException().isThrownBy(
+			() -> store.scheduleDestruction(definition.getName(), "key-1"));
+
+		verify(repository).updateKeyStatus(assertArg(t -> {
+			assertThat(t.getKeysetName()).isEqualTo(definition.getName());
+			assertThat(t.getKeyId()).isEqualTo("key-1");
+			assertThat(t.getStatus()).isEqualTo(KeyStatus.PENDING_DESTRUCTION);
+			assertThat(t.getDestructionScheduledAt()).isNotNull();
+			assertThat(t.getDestroyedAt()).isNull();
+		}));
+		verify(cache).evict(definition.getName());
+	}
+
+	@Test
+	@DisplayName("should immediately destroy the key when no grace period is configured")
+	void shouldImmediatelyDestroyKeyWhenNoGracePeriod() throws IOException {
+		final EncryptedKeyset noGracePeriod = EncryptedKeyset.builder()
+			.name(definition.getName())
+			.purpose(definition.getPurpose())
+			.factory(definition.getAlgorithm().factory())
+			.provider(kek.getProvider())
+			.keyEncryptionKey(kek.getId())
+			.build(List.of(encryptedKey("key-1", KeyStatus.DISABLED)));
+		repository.write(noGracePeriod);
+
+		assertThatNoException().isThrownBy(
+			() -> store.scheduleDestruction(definition.getName(), "key-1"));
+
+		final ArgumentCaptor<KeyTransition> captor = ArgumentCaptor.forClass(KeyTransition.class);
+		verify(repository, times(2)).updateKeyStatus(captor.capture());
+
+		assertThat(captor.getAllValues().get(0)).satisfies(t -> {
+			assertThat(t.getKeysetName()).isEqualTo(definition.getName());
+			assertThat(t.getKeyId()).isEqualTo("key-1");
+			assertThat(t.getStatus()).isEqualTo(KeyStatus.PENDING_DESTRUCTION);
+			assertThat(t.getDestructionScheduledAt()).isNotNull();
+			assertThat(t.getDestroyedAt()).isNull();
+		});
+		assertThat(captor.getAllValues().get(1)).satisfies(t -> {
+			assertThat(t.getKeysetName()).isEqualTo(definition.getName());
+			assertThat(t.getKeyId()).isEqualTo("key-1");
+			assertThat(t.getStatus()).isEqualTo(KeyStatus.DESTROYED);
+			assertThat(t.getDestructionScheduledAt()).isNull();
+			assertThat(t.getDestroyedAt()).isNotNull();
+		});
+	}
+
+	@Test
+	@DisplayName("should cancel a scheduled destruction and return the key to DISABLED")
+	void shouldCancelDestruction() throws IOException {
+		repository.write(keysetWith("key-1", KeyStatus.PENDING_DESTRUCTION));
+
+		assertThatNoException().isThrownBy(
+			() -> store.cancelDestruction(definition.getName(), "key-1"));
+
+		verify(repository).updateKeyStatus(KeyTransition.cancelDestruction(definition.getName(), "key-1"));
+		verify(cache).evict(definition.getName());
+	}
+
+	@Test
+	@DisplayName("should destroy a PENDING_DESTRUCTION key and stamp the destroyed-at timestamp")
+	void shouldDestroyKey() throws IOException {
+		repository.write(keysetWith("key-1", KeyStatus.PENDING_DESTRUCTION));
+
+		assertThatNoException().isThrownBy(() -> store.destroy(definition.getName(), "key-1"));
+
+		verify(repository).updateKeyStatus(assertArg(t -> {
+			assertThat(t.getKeysetName()).isEqualTo(definition.getName());
+			assertThat(t.getKeyId()).isEqualTo("key-1");
+			assertThat(t.getStatus()).isEqualTo(KeyStatus.DESTROYED);
+			assertThat(t.getDestroyedAt()).isNotNull();
+		}));
+		verify(cache).evict(definition.getName());
+	}
+
+	@Test
+	@DisplayName("should throw InvalidKeyStatusTransitionException for an invalid transition")
+	void shouldFailOnInvalidKeyStatusTransition() throws IOException {
+		repository.write(keysetWith("key-1", KeyStatus.ENABLED));
+
+		assertThatExceptionOfType(CryptoException.InvalidKeyStatusTransitionException.class)
+			.isThrownBy(() -> store.scheduleDestruction(definition.getName(), "key-1", Instant.now()))
+			.returns(definition.getName(), CryptoException.KeysetException::getName)
+			.returns("key-1", CryptoException.InvalidKeyStatusTransitionException::getKeyId)
+			.returns(KeyStatus.ENABLED, CryptoException.InvalidKeyStatusTransitionException::getCurrentStatus)
+			.returns(KeyStatus.PENDING_DESTRUCTION,
+				CryptoException.InvalidKeyStatusTransitionException::getAttemptedStatus);
+	}
+
+	@Test
+	@DisplayName("should throw KeysetException when the key identifier is not found in the keyset")
+	void shouldFailWhenKeyNotFoundInKeyset() throws IOException {
+		repository.write(keysetWith("key-1", KeyStatus.ENABLED));
+
+		assertThatExceptionOfType(CryptoException.KeysetException.class)
+			.isThrownBy(() -> store.disable(definition.getName(), "missing-key"))
+			.withMessageContaining("missing-key")
+			.returns(definition.getName(), CryptoException.KeysetException::getName);
+	}
+
+	@Test
+	@DisplayName("should throw KeysetNotFoundException when disabling a key in a missing keyset")
+	void shouldFailToDisableKeyInMissingKeyset() {
+		assertThatExceptionOfType(CryptoException.KeysetNotFoundException.class)
+			.isThrownBy(() -> store.disable("missing-keyset", "key-1"))
+			.returns("missing-keyset", CryptoException.KeysetException::getName);
+	}
+
+	private EncryptedKeyset keysetWith(String keyId, KeyStatus status) {
+		return EncryptedKeyset.builder(definition)
+			.provider(kek.getProvider())
+			.keyEncryptionKey(kek.getId())
+			.build(List.of(encryptedKey(keyId, status)));
+	}
+
+	private static EncryptedKey encryptedKey(String id, KeyStatus status) {
+		return EncryptedKey.builder()
+			.id(id)
+			.algorithm(TestAlgorithm.INSTANCE)
+			.status(status)
+			.primary(true)
+			.createdAt(Instant.now())
+			.build(ByteArray.fromString("key-material"));
 	}
 
 }

--- a/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
+++ b/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -141,6 +142,31 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 			WHERE KEYSET_NAME = ?
 			""";
 
+	private static final String UPDATE_KEY_STATUS_QUERY = """
+			UPDATE %KEYS_TABLE_NAME%
+			SET KEY_STATUS = ?, DESTRUCTION_SCHEDULED_AT = ?, DESTROYED_AT = ?
+			WHERE KEYSET_NAME = ? AND KEY_ID = ?
+			""";
+
+	private static final String DESTROY_KEY_QUERY = """
+			UPDATE %KEYS_TABLE_NAME%
+			SET KEY_STATUS = 'DESTROYED', KEY_DATA = NULL, DESTRUCTION_SCHEDULED_AT = NULL, DESTROYED_AT = ?
+			WHERE KEYSET_NAME = ? AND KEY_ID = ?
+			""";
+
+	private static final String FIND_PENDING_DESTRUCTION_QUERY = """
+			SELECT K.KEYSET_NAME, K.KEYSET_PURPOSE, K.KEYSET_FACTORY, K.KEYSET_PROVIDER, K.KEYSET_KEK,
+				K.ROTATION_INTERVAL, K.DESTRUCTION_GRACE_PERIOD,
+				E.KEY_ID, E.KEY_ALGORITHM, E.KEY_TYPE, E.KEY_STATUS, E.KEY_PRIMARY, E.KEY_DATA,
+				E.CREATED_AT, E.INITIALIZED_AT, E.EXPIRES_AT, E.DESTRUCTION_SCHEDULED_AT, E.DESTROYED_AT
+			FROM %TABLE_NAME% K
+			INNER JOIN %KEYS_TABLE_NAME% E ON E.KEYSET_NAME = K.KEYSET_NAME
+			WHERE E.KEY_STATUS = 'PENDING_DESTRUCTION'
+				AND E.DESTRUCTION_SCHEDULED_AT IS NOT NULL
+				AND E.DESTRUCTION_SCHEDULED_AT <= ?
+			ORDER BY K.KEYSET_NAME, E.KEY_ID
+			""";
+
 	/* Configurable table names and query overrides */
 
 	private String tableName = DEFAULT_TABLE_NAME;
@@ -167,6 +193,12 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 
 	private String deleteKeysetQuery;
 
+	private String updateKeyStatusQuery;
+
+	private String destroyKeyQuery;
+
+	private String findPendingDestructionQuery;
+
 	private final JdbcOperations jdbcOperations;
 
 	private final TransactionOperations transactionOperations;
@@ -186,6 +218,9 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 		deleteKeyQuery = sql(deleteKeyQuery, DELETE_KEY_QUERY);
 		deleteKeysQuery = sql(deleteKeysQuery, DELETE_KEYS_QUERY);
 		deleteKeysetQuery = sql(deleteKeysetQuery, DELETE_KEYSET_QUERY);
+		updateKeyStatusQuery = sql(updateKeyStatusQuery, UPDATE_KEY_STATUS_QUERY);
+		destroyKeyQuery = sql(destroyKeyQuery, DESTROY_KEY_QUERY);
+		findPendingDestructionQuery = sql(findPendingDestructionQuery, FIND_PENDING_DESTRUCTION_QUERY);
 	}
 
 	@NonNull
@@ -336,6 +371,83 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 			setInstant(ps, 11, key.getDestructionScheduledAt());
 			setInstant(ps, 12, key.getDestroyedAt());
 		});
+	}
+
+	@Override
+	public void updateKeyStatus(@NonNull KeyTransition transition) {
+		log.debug("Updating key '{}' in keyset '{}' to status {}",
+				transition.getKeyId(), transition.getKeysetName(), transition.getStatus());
+
+		if (transition.getStatus() == KeyStatus.DESTROYED) {
+			jdbcOperations.update(destroyKeyQuery, ps -> {
+				setInstant(ps, 1, transition.getDestroyedAt());
+				ps.setString(2, transition.getKeysetName());
+				ps.setString(3, transition.getKeyId());
+			});
+		}
+		else {
+			jdbcOperations.update(updateKeyStatusQuery, ps -> {
+				ps.setString(1, transition.getStatus().name());
+				setInstant(ps, 2, transition.getDestructionScheduledAt());
+				setInstant(ps, 3, transition.getDestroyedAt());
+				ps.setString(4, transition.getKeysetName());
+				ps.setString(5, transition.getKeyId());
+			});
+		}
+	}
+
+	@NonNull
+	@Override
+	public List<EncryptedKeyset> findPendingDestruction() {
+		log.debug("Querying for keys pending destruction");
+
+		return transactionOperations.execute(status ->
+			jdbcOperations.query(
+				findPendingDestructionQuery,
+				pss -> pss.setLong(1, Instant.now().toEpochMilli()),
+				this::extractPendingDestruction));
+	}
+
+	private List<EncryptedKeyset> extractPendingDestruction(
+			@NonNull ResultSet rs) throws SQLException, DataAccessException {
+		final Map<String, EncryptedKeyset.Builder> builders = new LinkedHashMap<>();
+		final Map<String, List<EncryptedKey>> keysByName = new LinkedHashMap<>();
+
+		while (rs.next()) {
+			final String name = rs.getString("KEYSET_NAME");
+			if (!builders.containsKey(name)) {
+				builders.put(name, extractKeysetRow(rs));
+			}
+			keysByName.computeIfAbsent(name, k -> new ArrayList<>()).add(convertKey(rs));
+		}
+
+		final List<EncryptedKeyset> result = new ArrayList<>(builders.size());
+		for (Map.Entry<String, EncryptedKeyset.Builder> entry : builders.entrySet()) {
+			final List<EncryptedKey> keys = keysByName.getOrDefault(entry.getKey(), List.of());
+			result.add(entry.getValue().build(keys));
+		}
+		return result;
+	}
+
+	private EncryptedKeyset.Builder extractKeysetRow(@NonNull ResultSet rs) throws SQLException {
+		final EncryptedKeyset.Builder builder = EncryptedKeyset.builder()
+			.name(rs.getString("KEYSET_NAME"))
+			.purpose(KeysetPurpose.valueOf(rs.getString("KEYSET_PURPOSE")))
+			.factory(rs.getString("KEYSET_FACTORY"))
+			.provider(rs.getString("KEYSET_PROVIDER"))
+			.keyEncryptionKey(rs.getString("KEYSET_KEK"));
+
+		final long rotationInterval = rs.getLong("ROTATION_INTERVAL");
+		if (!rs.wasNull()) {
+			builder.rotationInterval(rotationInterval);
+		}
+
+		final long destructionGracePeriod = rs.getLong("DESTRUCTION_GRACE_PERIOD");
+		if (!rs.wasNull()) {
+			builder.destructionGracePeriod(destructionGracePeriod);
+		}
+
+		return builder;
 	}
 
 	private boolean exists(@NonNull String name) {

--- a/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
+++ b/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
@@ -3,6 +3,7 @@ package com.konfigyr.crypto.jdbc;
 import com.konfigyr.crypto.*;
 import com.konfigyr.crypto.test.TestAlgorithm;
 import com.konfigyr.io.ByteArray;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,12 +87,143 @@ class JdbcKeysetRepositoryTest {
 		assertThat(repository.read(definition.getName())).isEmpty();
 	}
 
+	@Test
+	@DisplayName("should update key status without altering key data")
+	void shouldUpdateKeyStatus() throws IOException {
+		final Instant t0 = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+		final EncryptedKey key = encryptedKey("key-1", true, t0, ByteArray.fromString("secret"));
+		repository.write(encryptedKeyset("lifecycle-status", key));
+
+		assertThatNoException().isThrownBy(() ->
+			repository.updateKeyStatus(KeyTransition.disable("lifecycle-status", "key-1")));
+
+		assertThat(repository.read("lifecycle-status"))
+			.isPresent()
+			.hasValueSatisfying(ks ->
+				assertThat(ks.getKey("key-1"))
+					.isPresent()
+					.hasValueSatisfying(k -> {
+						assertThat(k.getStatus()).isEqualTo(KeyStatus.DISABLED);
+						assertThat(k.getData()).isNotNull();
+					})
+			);
+
+		repository.remove("lifecycle-status");
+	}
+
+	@Test
+	@DisplayName("should erase key data and set destroyed-at when key is destroyed")
+	void shouldDestroyKeyAndEraseData() throws IOException {
+		final Instant t0 = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+		final Instant scheduled = t0.minus(Duration.ofDays(1));
+		final EncryptedKey key = EncryptedKey.builder()
+			.id("key-1")
+			.algorithm(TestAlgorithm.INSTANCE)
+			.status(KeyStatus.PENDING_DESTRUCTION)
+			.primary(true)
+			.createdAt(t0)
+			.destructionScheduledAt(scheduled)
+			.build(ByteArray.fromString("secret"));
+		repository.write(encryptedKeyset("lifecycle-destroy", key));
+
+		final Instant destroyedAt = t0.plusSeconds(1);
+		assertThatNoException().isThrownBy(() ->
+			repository.updateKeyStatus(KeyTransition.destroy("lifecycle-destroy", "key-1", destroyedAt)));
+
+		assertThat(repository.read("lifecycle-destroy"))
+			.isPresent()
+			.hasValueSatisfying(ks ->
+				assertThat(ks.getKey("key-1"))
+					.isPresent()
+					.hasValueSatisfying(k -> {
+						assertThat(k.getStatus()).isEqualTo(KeyStatus.DESTROYED);
+						assertThat(k.getData()).isNull();
+						assertThat(k.getDestroyedAt()).isEqualTo(destroyedAt);
+					})
+			);
+
+		repository.remove("lifecycle-destroy");
+	}
+
+	@Test
+	@DisplayName("should return only keys whose scheduled destruction time has elapsed")
+	void shouldFindKeysPendingDestruction() throws IOException {
+		final Instant t0 = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+		final Instant pastSchedule = t0.minus(Duration.ofDays(1));
+		final Instant futureSchedule = t0.plus(Duration.ofDays(7));
+
+		final EncryptedKey pastKey = EncryptedKey.builder()
+			.id("past-key")
+			.algorithm(TestAlgorithm.INSTANCE)
+			.status(KeyStatus.PENDING_DESTRUCTION)
+			.primary(true)
+			.createdAt(t0)
+			.destructionScheduledAt(pastSchedule)
+			.build(ByteArray.fromString("secret"));
+
+		final EncryptedKey futureKey = EncryptedKey.builder()
+			.id("future-key")
+			.algorithm(TestAlgorithm.INSTANCE)
+			.status(KeyStatus.PENDING_DESTRUCTION)
+			.primary(false)
+			.createdAt(t0)
+			.destructionScheduledAt(futureSchedule)
+			.build(ByteArray.fromString("secret"));
+
+		repository.write(encryptedKeyset("lifecycle-pending", pastKey, futureKey));
+
+		final var results = repository.findPendingDestruction();
+
+		assertThat(results)
+			.hasSize(1)
+			.first()
+			.returns("lifecycle-pending", EncryptedKeyset::getName)
+			.extracting(EncryptedKeyset::getKeys, InstanceOfAssertFactories.iterable(EncryptedKey.class))
+			.hasSize(1)
+			.first()
+			.returns("past-key", EncryptedKey::getId);
+
+		repository.remove("lifecycle-pending");
+	}
+
+	@Test
+	@DisplayName("should return empty list when no keys have an elapsed destruction schedule")
+	void shouldNotFindFutureScheduledKeys() throws IOException {
+		final Instant t0 = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+		final EncryptedKey futureKey = EncryptedKey.builder()
+			.id("future-key")
+			.algorithm(TestAlgorithm.INSTANCE)
+			.status(KeyStatus.PENDING_DESTRUCTION)
+			.primary(true)
+			.createdAt(t0)
+			.destructionScheduledAt(t0.plus(Duration.ofDays(30)))
+			.build(ByteArray.fromString("secret"));
+
+		repository.write(encryptedKeyset("lifecycle-future", futureKey));
+
+		assertThat(repository.findPendingDestruction())
+			.extracting(EncryptedKeyset::getName)
+			.doesNotContain("lifecycle-future");
+
+		repository.remove("lifecycle-future");
+	}
+
 	@NonNull
-	private static EncryptedKeyset encryptedKeyset(EncryptedKey... keys) {
-		return EncryptedKeyset.builder(definition)
+	private static EncryptedKeyset encryptedKeyset(String name, EncryptedKey... keys) {
+		return EncryptedKeyset.builder()
+			.name(name)
+			.purpose(KeysetPurpose.ENCRYPTION)
+			.factory(TestAlgorithm.INSTANCE.factory())
 			.provider("test-provider")
 			.keyEncryptionKey("test-kek")
+			.rotationInterval(Duration.ofDays(180))
+			.destructionGracePeriod(Duration.ofDays(30))
 			.build(keys);
+	}
+
+	@NonNull
+	private static EncryptedKeyset encryptedKeyset(EncryptedKey... keys) {
+		return encryptedKeyset(definition.getName(), keys);
 	}
 
 	@NonNull


### PR DESCRIPTION
Add NIST SP 800-57 §8.3 compliant lifecycle transitions at the key-version level (disable → pending-destruction → destroyed), mirroring the GCP KMS CryptoKeyVersion model.

Before this change `KeysetStore` only covered create/read/write/rotate/remove. No deactivation step existed before hard-deleting a keyset; key material was either live or gone with no audit trail.
  
This change adds six new operations (disable, enable, scheduleDestruction, cancelDestruction, destroy, plus the no-arg scheduleDestruction that destroys immediately when no grace period is configured).