### PR TITLE
Fix timing oracle in JOSE verify/decrypt

### DIFF
--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/io/ByteArray.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/io/ByteArray.java
@@ -1,6 +1,7 @@
 package com.konfigyr.io;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.io.InputStreamSource;
 import org.springframework.core.io.buffer.DataBuffer;
 
@@ -11,6 +12,7 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Base64;
 
@@ -242,6 +244,39 @@ public final class ByteArray implements InputStreamSource, Serializable {
 		return array.length;
 	}
 
+	/**
+	 * Compares this {@link ByteArray} to another in constant time using {@link MessageDigest#isEqual(byte[], byte[])}.
+	 * <p>
+	 * Use this method, rather than {@link #equals(Object)}, whenever comparing ciphertext, signatures,
+	 * MAC values, or key material, to prevent timing side-channel attacks.
+	 *
+	 * @param other the byte array to compare against, may be {@literal null}
+	 * @return {@code true} if both arrays have identical contents, {@code false} otherwise
+	 */
+	public boolean constantTimeEquals(byte @Nullable [] other) {
+		return other != null && MessageDigest.isEqual(this.array, other);
+	}
+
+	/**
+	 * Compares this {@link ByteArray} to another in constant time using {@link MessageDigest#isEqual(byte[], byte[])}.
+	 * <p>
+	 * Use this method, rather than {@link #equals(Object)}, whenever comparing ciphertext, signatures,
+	 * MAC values, or key material, to prevent timing side-channel attacks.
+	 *
+	 * @param other the byte array to compare against, may be {@literal null}
+	 * @return {@code true} if both arrays have identical contents, {@code false} otherwise
+	 */
+	public boolean constantTimeEquals(@Nullable ByteArray other) {
+		return constantTimeEquals(other == null ? null : other.array);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * <strong>Security note:</strong> this method uses {@link Arrays#equals(byte[], byte[])} which is
+	 * <em>not</em> constant-time. Never use it to compare ciphertext, signatures, MAC values, or key
+	 * material. Use {@link #constantTimeEquals(ByteArray)} instead.
+	 */
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/io/ByteArrayTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/io/ByteArrayTest.java
@@ -185,6 +185,18 @@ class ByteArrayTest {
 	}
 
 	@Test
+	@DisplayName("should compare byte arrays in constant time")
+	void shouldCompareInConstantTime() {
+		final var data = ByteArray.fromString(TEST_ORIGINAL);
+
+		assertThat(data.constantTimeEquals(ByteArray.fromString(TEST_ORIGINAL))).isTrue();
+		assertThat(data.constantTimeEquals(ByteArray.fromString("different string"))).isFalse();
+		assertThat(data.constantTimeEquals(ByteArray.fromString("short"))).isFalse();
+		assertThat(data.constantTimeEquals((ByteArray) null)).isFalse();
+		assertThat(ByteArray.empty().constantTimeEquals(ByteArray.empty())).isTrue();
+	}
+
+	@Test
 	@DisplayName("should perform identity and equality checks based on the contents")
 	void shouldCheckEquality() {
 		final var foo = ByteArray.fromString("foo array");

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JsonWebKeyset.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JsonWebKeyset.java
@@ -75,7 +75,7 @@ class JsonWebKeyset extends AbstractKeyset<JsonWebKey> implements JWKSource<Secu
 			final JWEObject object = JWEObject.parse(new String(cipher.array(), StandardCharsets.UTF_8));
 			final ByteArray aad = JoseUtils.resolveAdditionalAuthenticationData(object.getHeader());
 
-			if (!Objects.equals(context, aad)) {
+			if (!(context != null ? context.constantTimeEquals(aad) : aad == null)) {
 				throw new CryptoException.KeysetOperationException(name, KeysetOperation.DECRYPT,
 					"AAD does not match the expected value");
 			}
@@ -119,7 +119,7 @@ class JsonWebKeyset extends AbstractKeyset<JsonWebKey> implements JWKSource<Secu
 				return false;
 			}
 
-			return Arrays.equals(object.getPayload().toBytes(), data.array());
+			return data.constantTimeEquals(object.getPayload().toBytes());
 		} catch (ParseException e) {
 			return false;
 		} catch (JOSEException e) {


### PR DESCRIPTION
- `ByteArray`: added `constantTimeEquals(ByteArray)` and `constantTimeEquals(byte[])` overloads backed by `MessageDigest.isEqual`; updated `equals()` Javadoc to warn against use on cryptographic values
- `JsonWebKeyset.verify`: replaced `Arrays.equals` payload comparison with `constantTimeEquals` to prevent timing oracle attacks
 - Updated `JsonWebKeyset.decrypt` AAD check and `verify` payload check to use `constantTimeEquals` throughout 
