### PR TITLE
 Harden cryptographic key handling and input validation

### DIFF
--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKeyEncryptionKey.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKeyEncryptionKey.java
@@ -55,7 +55,7 @@ public abstract class AbstractKeyEncryptionKey implements KeyEncryptionKey {
 
 	@Override
 	public String toString() {
-		return provider + "@" + id;
+		return KeyEncryptionKey.format(this);
 	}
 
 	@Override

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKeyset.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKeyset.java
@@ -242,7 +242,7 @@ public abstract class AbstractKeyset<T extends Key> implements Keyset {
 			.add("name='" + name + "'")
 			.add("factory=" + factory)
 			.add("purpose=" + purpose)
-			.add("kek=" + keyEncryptionKey)
+			.add("kek=" + KeyEncryptionKey.format(keyEncryptionKey))
 			.add("keys=" + keys)
 			.add("rotationInterval=" + rotationInterval)
 			.add("destructionGracePeriod=" + destructionGracePeriod)

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoAutoConfiguration.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoAutoConfiguration.java
@@ -1,5 +1,6 @@
 package com.konfigyr.crypto;
 
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -25,6 +26,7 @@ import org.springframework.context.annotation.Bean;
  * @author Vladimir Spasic
  * @since 1.0.0
  **/
+@Slf4j
 @AutoConfiguration
 @ConditionalOnBean(KeysetFactory.class)
 @ConditionalOnMissingBean(KeysetStore.class)
@@ -41,6 +43,9 @@ public class CryptoAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(KeysetRepository.class)
 	KeysetRepository inMemoryKeysetRepository() {
+		log.warn("InMemoryKeysetRepository is being used. All key material will be lost on restart. "
+				+ "Do not use in production. Add the 'konfigyr-crypto-jdbc' module for a persistent "
+				+ "repository, or implement KeysetRepository with your own storage backend.");
 		return new InMemoryKeysetRepository();
 	}
 

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyEncryptionKey.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyEncryptionKey.java
@@ -65,4 +65,15 @@ public interface KeyEncryptionKey {
 	 */
 	ByteArray unwrap(ByteArray data) throws IOException;
 
+	/**
+	 * Formats the given {@link KeyEncryptionKey} as a safe log-friendly reference string
+	 * containing only the provider name and key identifier — never key material.
+	 *
+	 * @param kek the key encryption key to format, can't be {@literal null}
+	 * @return a {@code provider@id} string, never {@literal null}
+	 */
+	static String format(KeyEncryptionKey kek) {
+		return kek.getProvider() + "@" + kek.getId();
+	}
+
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepostoryKeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepostoryKeysetStore.java
@@ -3,6 +3,7 @@ package com.konfigyr.crypto;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -69,6 +70,9 @@ public class RepostoryKeysetStore implements KeysetStore {
 
 	@Override
 	public Keyset create(String provider, String kek, KeysetDefinition definition) {
+		Assert.hasText(provider, "Provider name must not be blank");
+		Assert.hasText(kek, "Key encryption key ID must not be blank");
+
 		final KeysetFactory factory = lookupFactory(definition);
 
 		return create(factory, kek(provider, kek), definition);
@@ -83,6 +87,8 @@ public class RepostoryKeysetStore implements KeysetStore {
 
 	@Override
 	public Keyset read(String name) {
+		Assert.hasText(name, "Keyset name must not be blank");
+
 		final EncryptedKeyset encryptedKeyset = lookupKeyset(name);
 		final KeysetFactory factory = lookupFactory(encryptedKeyset);
 
@@ -98,6 +104,8 @@ public class RepostoryKeysetStore implements KeysetStore {
 
 	@Override
 	public void rotate(String name) {
+		Assert.hasText(name, "Keyset name must not be blank");
+
 		final EncryptedKeyset encryptedKeyset = lookupKeyset(name);
 
 		rotate(read(lookupFactory(encryptedKeyset), encryptedKeyset));
@@ -110,6 +118,8 @@ public class RepostoryKeysetStore implements KeysetStore {
 
 	@Override
 	public void rotate(String name, KeyDefinition definition) {
+		Assert.hasText(name, "Keyset name must not be blank");
+
 		final EncryptedKeyset encryptedKeyset = lookupKeyset(name);
 
 		rotate(read(lookupFactory(encryptedKeyset), encryptedKeyset), definition);
@@ -125,6 +135,8 @@ public class RepostoryKeysetStore implements KeysetStore {
 
 	@Override
 	public void remove(String name) {
+		Assert.hasText(name, "Keyset name must not be blank");
+
 		if (logger.isDebugEnabled()) {
 			logger.debug("Removing encrypted keyset data with name: {}", name);
 		}
@@ -146,40 +158,63 @@ public class RepostoryKeysetStore implements KeysetStore {
 
 	@Override
 	public void disable(String keysetName, String keyId) {
+		Assert.hasText(keysetName, "Keyset name must not be blank");
+		Assert.hasText(keyId, "Key ID must not be blank");
+
 		performKeyTransition(KeyTransition.disable(keysetName, keyId), KeyStatus.ENABLED);
 	}
 
 	@Override
 	public void enable(String keysetName, String keyId) {
+		Assert.hasText(keysetName, "Keyset name must not be blank");
+		Assert.hasText(keyId, "Key ID must not be blank");
+
 		performKeyTransition(KeyTransition.enable(keysetName, keyId), KeyStatus.DISABLED);
 	}
 
 	@Override
 	public void scheduleDestruction(String keysetName, String keyId) {
+		Assert.hasText(keysetName, "Keyset name must not be blank");
+		Assert.hasText(keyId, "Key ID must not be blank");
+
 		final EncryptedKeyset encryptedKeyset = lookupKeyset(keysetName);
 		final Duration gracePeriod = encryptedKeyset.getDestructionGracePeriod();
+		final Instant destructionTime = gracePeriod != null
+				? Instant.now().plus(gracePeriod)
+				: Instant.now();
+
+		performKeyTransition(KeyTransition.scheduleDestruction(keysetName, keyId, destructionTime),
+				KeyStatus.DISABLED);
+
 		if (gracePeriod == null) {
-			scheduleDestruction(keysetName, keyId, Instant.now());
 			destroy(keysetName, keyId);
-		} else {
-			scheduleDestruction(keysetName, keyId, Instant.now().plus(gracePeriod));
 		}
 	}
 
 	@Override
 	public void scheduleDestruction(String keysetName, String keyId, Instant destructionTime) {
+		Assert.hasText(keysetName, "Keyset name must not be blank");
+		Assert.hasText(keyId, "Key ID must not be blank");
+		Assert.isTrue(destructionTime.isAfter(Instant.now()), "Destruction time must be in the future");
+
 		performKeyTransition(KeyTransition.scheduleDestruction(keysetName, keyId, destructionTime),
 				KeyStatus.DISABLED);
 	}
 
 	@Override
 	public void cancelDestruction(String keysetName, String keyId) {
+		Assert.hasText(keysetName, "Keyset name must not be blank");
+		Assert.hasText(keyId, "Key ID must not be blank");
+
 		performKeyTransition(KeyTransition.cancelDestruction(keysetName, keyId),
 				KeyStatus.PENDING_DESTRUCTION);
 	}
 
 	@Override
 	public void destroy(String keysetName, String keyId) {
+		Assert.hasText(keysetName, "Keyset name must not be blank");
+		Assert.hasText(keyId, "Key ID must not be blank");
+
 		performKeyTransition(KeyTransition.destroy(keysetName, keyId, Instant.now()),
 				KeyStatus.PENDING_DESTRUCTION);
 	}
@@ -296,7 +331,8 @@ public class RepostoryKeysetStore implements KeysetStore {
 	 */
 	protected Keyset create(KeysetFactory factory, KeyEncryptionKey kek, KeysetDefinition definition) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("Attempting to generate Keyset with [definition={}, kek={}]", definition, kek);
+			logger.debug("Attempting to generate Keyset with [definition={}, kek={}]", definition,
+					KeyEncryptionKey.format(kek));
 		}
 
 		final Keyset keyset;
@@ -357,7 +393,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 		}
 
 		if (logger.isDebugEnabled()) {
-			logger.debug("Writing encrypted keyset data for: {}", keyset);
+			logger.debug("Writing encrypted keyset data for: {}", keyset.getName());
 		}
 
 		try {

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/CryptoAutoConfigurationTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/CryptoAutoConfigurationTest.java
@@ -11,10 +11,12 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.context.annotation.Configurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({ MockitoExtension.class, OutputCaptureExtension.class })
 class CryptoAutoConfigurationTest {
 
 	final Configurations configurations = AutoConfigurations.of(CryptoAutoConfiguration.class);
@@ -97,6 +99,30 @@ class CryptoAutoConfigurationTest {
 				.getBean(KeysetRepository.class)
 				.isEqualTo(repository)
 			);
+	}
+
+	@Test
+	@DisplayName("should emit a WARN log when InMemoryKeysetRepository is auto-configured")
+	void shouldWarnWhenInMemoryRepositoryIsAutoConfigured(CapturedOutput output) {
+		runner.withBean(KeyEncryptionKeyProvider.class, () -> provider).run(ctx -> {
+			assertThat(ctx).hasNotFailed().hasSingleBean(InMemoryKeysetRepository.class);
+			assertThat(output).contains("InMemoryKeysetRepository is being used")
+					.contains("konfigyr-crypto-jdbc")
+					.contains("KeysetRepository");
+		});
+	}
+
+	@Test
+	@DisplayName("should not emit in-memory WARN when a custom KeysetRepository is provided")
+	void shouldNotWarnWhenCustomRepositoryIsProvided(CapturedOutput output) {
+		final var repository = Mockito.mock(KeysetRepository.class);
+
+		runner.withBean(KeysetRepository.class, () -> repository)
+			.withBean(KeyEncryptionKeyProvider.class, () -> provider)
+			.run(ctx -> {
+				assertThat(ctx).hasNotFailed().doesNotHaveBean(InMemoryKeysetRepository.class);
+				assertThat(output).doesNotContain("InMemoryKeysetRepository is being used");
+			});
 	}
 
 }

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepostoryKeysetStoreTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepostoryKeysetStoreTest.java
@@ -554,7 +554,8 @@ class RepostoryKeysetStoreTest {
 		repository.write(keysetWith("key-1", KeyStatus.ENABLED));
 
 		assertThatExceptionOfType(CryptoException.InvalidKeyStatusTransitionException.class)
-			.isThrownBy(() -> store.scheduleDestruction(definition.getName(), "key-1", Instant.now()))
+			.isThrownBy(() -> store.scheduleDestruction(definition.getName(), "key-1",
+					Instant.now().plusSeconds(60)))
 			.returns(definition.getName(), CryptoException.KeysetException::getName)
 			.returns("key-1", CryptoException.InvalidKeyStatusTransitionException::getKeyId)
 			.returns(KeyStatus.ENABLED, CryptoException.InvalidKeyStatusTransitionException::getCurrentStatus)
@@ -579,6 +580,101 @@ class RepostoryKeysetStoreTest {
 		assertThatExceptionOfType(CryptoException.KeysetNotFoundException.class)
 			.isThrownBy(() -> store.disable("missing-keyset", "key-1"))
 			.returns("missing-keyset", CryptoException.KeysetException::getName);
+	}
+
+	@Test
+	@DisplayName("should reject null or blank names on read")
+	void shouldRejectBlankNameOnRead() {
+		assertThatIllegalArgumentException().isThrownBy(() -> store.read(null));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.read(""));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.read("  "));
+	}
+
+	@Test
+	@DisplayName("should reject null or blank provider/kek names on create")
+	void shouldRejectBlankNamesOnCreate() {
+		assertThatIllegalArgumentException().isThrownBy(() -> store.create(null, kek.getId(), definition));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.create("", kek.getId(), definition));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.create(kek.getProvider(), null, definition));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.create(kek.getProvider(), "", definition));
+	}
+
+	@Test
+	@DisplayName("should reject null or blank names on rotate")
+	void shouldRejectBlankNameOnRotate() {
+		assertThatIllegalArgumentException().isThrownBy(() -> store.rotate(""));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.rotate("  "));
+	}
+
+	@Test
+	@DisplayName("should reject null or blank names on remove")
+	void shouldRejectBlankNameOnRemove() {
+		assertThatIllegalArgumentException().isThrownBy(() -> store.remove((String) null));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.remove(""));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.remove("  "));
+	}
+
+	@Test
+	@DisplayName("should reject null or blank names on disable")
+	void shouldRejectBlankNamesOnDisable() {
+		assertThatIllegalArgumentException().isThrownBy(() -> store.disable(null, "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.disable("", "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.disable(definition.getName(), null));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.disable(definition.getName(), ""));
+	}
+
+	@Test
+	@DisplayName("should reject null or blank names on enable")
+	void shouldRejectBlankNamesOnEnable() {
+		assertThatIllegalArgumentException().isThrownBy(() -> store.enable(null, "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.enable("", "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.enable(definition.getName(), null));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.enable(definition.getName(), ""));
+	}
+
+	@Test
+	@DisplayName("should reject null or blank names on scheduleDestruction")
+	void shouldRejectBlankNamesOnScheduleDestruction() {
+		final Instant future = Instant.now().plusSeconds(60);
+		assertThatIllegalArgumentException().isThrownBy(() -> store.scheduleDestruction(null, "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.scheduleDestruction("", "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.scheduleDestruction(definition.getName(), null));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.scheduleDestruction(definition.getName(), ""));
+		assertThatIllegalArgumentException().isThrownBy(
+			() -> store.scheduleDestruction(null, "key-1", future));
+		assertThatIllegalArgumentException().isThrownBy(
+			() -> store.scheduleDestruction("", "key-1", future));
+		assertThatIllegalArgumentException().isThrownBy(
+			() -> store.scheduleDestruction(definition.getName(), null, future));
+		assertThatIllegalArgumentException().isThrownBy(
+			() -> store.scheduleDestruction(definition.getName(), "", future));
+	}
+
+	@Test
+	@DisplayName("should reject a destruction time in the past or present")
+	void shouldRejectPastDestructionTime() {
+		assertThatIllegalArgumentException().isThrownBy(
+			() -> store.scheduleDestruction(definition.getName(), "key-1", Instant.now()));
+		assertThatIllegalArgumentException().isThrownBy(
+			() -> store.scheduleDestruction(definition.getName(), "key-1", Instant.now().minusSeconds(1)));
+	}
+
+	@Test
+	@DisplayName("should reject null or blank names on cancelDestruction")
+	void shouldRejectBlankNamesOnCancelDestruction() {
+		assertThatIllegalArgumentException().isThrownBy(() -> store.cancelDestruction(null, "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.cancelDestruction("", "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.cancelDestruction(definition.getName(), null));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.cancelDestruction(definition.getName(), ""));
+	}
+
+	@Test
+	@DisplayName("should reject null or blank names on destroy")
+	void shouldRejectBlankNamesOnDestroy() {
+		assertThatIllegalArgumentException().isThrownBy(() -> store.destroy(null, "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.destroy("", "key-1"));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.destroy(definition.getName(), null));
+		assertThatIllegalArgumentException().isThrownBy(() -> store.destroy(definition.getName(), ""));
 	}
 
 	private EncryptedKeyset keysetWith(String keyId, KeyStatus status) {

--- a/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
+++ b/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
@@ -221,6 +221,10 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 	public void afterPropertiesSet() {
 		Assert.hasText(tableName, "Table name for encrypted keysets can not be blank");
 		Assert.hasText(keysTableName, "Table name for encrypted keys can not be blank");
+		Assert.isTrue(tableName.matches("[A-Za-z][A-Za-z0-9_]*"),
+				"Keyset table name must be a valid SQL identifier: " + tableName);
+		Assert.isTrue(keysTableName.matches("[A-Za-z][A-Za-z0-9_]*"),
+				"Keys table name must be a valid SQL identifier: " + keysTableName);
 
 		getKeysetQuery = sql(getKeysetQuery, GET_KEYSET_QUERY);
 		getKeysQuery = sql(getKeysQuery, GET_KEYS_QUERY);

--- a/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
+++ b/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
@@ -12,6 +12,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.transaction.support.TransactionOperations;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -19,6 +22,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @AutoConfigureTestDatabase
@@ -34,6 +38,12 @@ class JdbcKeysetRepositoryTest {
 
 	@Autowired
 	KeysetRepository repository;
+
+	@Autowired
+	JdbcOperations jdbcOperations;
+
+	@Autowired
+	TransactionOperations transactionOperations;
 
 	@Test
 	@DisplayName("should manage Keysets in a database")
@@ -290,6 +300,25 @@ class JdbcKeysetRepositoryTest {
 			.primary(primary)
 			.createdAt(createdAt)
 			.build(data);
+	}
+
+	@Test
+	@DisplayName("should reject table names that are not valid SQL identifiers")
+	void shouldRejectInvalidTableNames() {
+		final var repo = new JdbcKeysetRepository(jdbcOperations, transactionOperations);
+
+		repo.setTableName("KEYSETS; DROP TABLE KEYSETS;--");
+		assertThatIllegalArgumentException().isThrownBy(repo::afterPropertiesSet);
+
+		repo.setTableName("1INVALID");
+		assertThatIllegalArgumentException().isThrownBy(repo::afterPropertiesSet);
+
+		repo.setTableName("KEYSETS");
+		repo.setKeysTableName("KEYSET_KEYS; DROP TABLE KEYSET_KEYS;--");
+		assertThatIllegalArgumentException().isThrownBy(repo::afterPropertiesSet);
+
+		repo.setKeysTableName("2INVALID");
+		assertThatIllegalArgumentException().isThrownBy(repo::afterPropertiesSet);
 	}
 
 	@SpringBootApplication

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAlgorithm.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAlgorithm.java
@@ -165,11 +165,18 @@ public final class JoseAlgorithm implements Algorithm {
 	 * ---------------------------------------------------------------------- */
 
 	/**
+	 * Preferred RSA key size in bits (3072), meeting NIST SP 800-131A Rev 2 guidance
+	 * for keys with security lifetimes beyond 2030 (112-bit strength minimum requires 2048;
+	 * 3072 provides 128-bit strength).
+	 */
+	private static final int PREFERRED_RSA_KEY_SIZE = 3072;
+
+	/**
 	 * RSA-OAEP with SHA-256. NIST SP 800-56B Rev 2.
 	 */
 	public static final JoseAlgorithm RSA_OAEP_256 = new JoseAlgorithm(
 		"jose:RSA-OAEP-256", KeyType.RSA, KeysetPurpose.ENCRYPTION, JWEAlgorithm.RSA_OAEP_256,
-		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+		() -> new RSAKeyGenerator(PREFERRED_RSA_KEY_SIZE)
 	);
 
 	/**
@@ -177,7 +184,7 @@ public final class JoseAlgorithm implements Algorithm {
 	 */
 	public static final JoseAlgorithm RSA_OAEP_384 = new JoseAlgorithm(
 		"jose:RSA-OAEP-384", KeyType.RSA, KeysetPurpose.ENCRYPTION, JWEAlgorithm.RSA_OAEP_384,
-		() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+		() -> new RSAKeyGenerator(PREFERRED_RSA_KEY_SIZE)
 	);
 
 	/**
@@ -281,18 +288,33 @@ public final class JoseAlgorithm implements Algorithm {
 	);
 
 	/**
-	 * List of all built-in JOSE algorithm constants.
+	 * List of all built-in JOSE algorithm constants that are registered automatically.
+	 * <p>
+	 * RSA-PKCS1v1.5 signing algorithms ({@link #RS256}, {@link #RS384}, {@link #RS512}) are
+	 * intentionally excluded. They are conditionally acceptable for JOSE interoperability only
+	 * (NIST SP 800-131A Rev 2) and must be opted in explicitly via {@link #LEGACY_ALGORITHMS}.
 	 */
 	public static final List<JoseAlgorithm> DEFAULT_ALGORITHMS = List.of(
 		HS256, HS384, HS512,
 		ES256, ES384, ES512,
 		PS256, PS384, PS512,
-		RS256, RS384, RS512,
 		RSA_OAEP_256, RSA_OAEP_384, RSA_OAEP_512,
 		A128KW, A192KW, A256KW,
 		A128GCMKW, A192GCMKW, A256GCMKW,
 		ECDH_ES, ECDH_ES_A128KW, ECDH_ES_A192KW, ECDH_ES_A256KW
 	);
+
+	/**
+	 * RSA-PKCS1v1.5 signing algorithms retained exclusively for interoperability with external
+	 * relying parties that require PKCS1v1.5 signatures (e.g. legacy JOSE / JWT consumers).
+	 * <p>
+	 * These algorithms are <strong>not</strong> registered automatically. They must be explicitly
+	 * enabled by setting {@code konfigyr.crypto.jose.register-legacy-algorithms=true}.
+	 * <p>
+	 * Do not use these algorithms in new designs. Prefer {@link #PS256}, {@link #PS384},
+	 * or {@link #PS512} instead (NIST SP 800-131A Rev 2).
+	 */
+	public static final List<JoseAlgorithm> LEGACY_ALGORITHMS = List.of(RS256, RS384, RS512);
 
 	private final String name;
 	private final KeyType type;

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAutoConfiguration.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAutoConfiguration.java
@@ -6,6 +6,7 @@ import com.konfigyr.crypto.CryptoAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -24,6 +25,12 @@ public class JoseAutoConfiguration {
 	@Bean
 	AlgorithmRegistrar joseAlgorithmRegistrar() {
 		return registry -> JoseAlgorithm.DEFAULT_ALGORITHMS.forEach(registry::register);
+	}
+
+	@Bean
+	@ConditionalOnProperty(name = "konfigyr.crypto.jose.register-legacy-algorithms", havingValue = "true")
+	AlgorithmRegistrar legacyJoseAlgorithmRegistrar() {
+		return registry -> JoseAlgorithm.LEGACY_ALGORITHMS.forEach(registry::register);
 	}
 
 	@Bean

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JsonWebKeyset.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JsonWebKeyset.java
@@ -52,6 +52,7 @@ class JsonWebKeyset extends AbstractKeyset<JsonWebKey> implements JWKSource<Secu
 
 	@Override
 	public ByteArray encrypt(ByteArray data, @Nullable ByteArray context) {
+		Assert.isTrue(!data.isEmpty(), "Cannot encrypt an empty byte array");
 		assertKeysetOperation(KeysetOperation.ENCRYPT);
 
 		final JsonWebKey key = getPrimary();
@@ -69,6 +70,7 @@ class JsonWebKeyset extends AbstractKeyset<JsonWebKey> implements JWKSource<Secu
 
 	@Override
 	public ByteArray decrypt(ByteArray cipher, @Nullable ByteArray context) {
+		Assert.isTrue(!cipher.isEmpty(), "Cannot decrypt an empty byte array");
 		assertKeysetOperation(KeysetOperation.DECRYPT);
 
 		try {
@@ -90,6 +92,7 @@ class JsonWebKeyset extends AbstractKeyset<JsonWebKey> implements JWKSource<Secu
 
 	@Override
 	public ByteArray sign(ByteArray data) {
+		Assert.isTrue(!data.isEmpty(), "Cannot sign an empty byte array");
 		assertKeysetOperation(KeysetOperation.SIGN);
 
 		final JsonWebKey key = getPrimary();
@@ -110,6 +113,8 @@ class JsonWebKeyset extends AbstractKeyset<JsonWebKey> implements JWKSource<Secu
 
 	@Override
 	public boolean verify(ByteArray signature, ByteArray data) {
+		Assert.isTrue(!signature.isEmpty(), "Cannot verify an empty signature");
+		Assert.isTrue(!data.isEmpty(), "Cannot verify a signature against an empty byte array");
 		assertKeysetOperation(KeysetOperation.VERIFY);
 
 		try {

--- a/konfigyr-crypto-jose/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/konfigyr-crypto-jose/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,17 @@
+{
+  "groups": [
+    {
+      "name": "konfigyr.crypto.jose",
+      "sourceType": "com.konfigyr.crypto.jose.JoseAutoConfiguration"
+    }
+  ],
+  "properties": [
+    {
+      "name": "konfigyr.crypto.jose.register-legacy-algorithms",
+      "type": "java.lang.Boolean",
+      "description": "Whether to register RSA-PKCS1v1.5 signing algorithms (RS256, RS384, RS512) for JOSE interoperability with external relying parties that require PKCS1v1.5 signatures. These algorithms are conditionally acceptable per NIST SP 800-131A Rev 2 and must not be used in new designs. Prefer PS256, PS384, or PS512 instead. Defaults to false.",
+      "sourceType": "com.konfigyr.crypto.jose.JoseAutoConfiguration",
+      "defaultValue": false
+    }
+  ]
+}

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseAutoConfigurationTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseAutoConfigurationTest.java
@@ -38,16 +38,37 @@ class JoseAutoConfigurationTest {
 	}
 
 	@Test
-	@DisplayName("should register the JOSE keyset factory")
+	@DisplayName("should register the JOSE keyset factory with default algorithms only")
 	void shouldApplyConfiguration() {
 		runner.run(ctx -> assertThat(ctx).hasNotFailed()
 			.hasSingleBean(JoseAutoConfiguration.class)
 			.hasSingleBean(JoseKeysetFactory.class)
 			.hasSingleBean(AlgorithmRegistry.class)
 			.getBean(AlgorithmRegistry.class)
-			.satisfies(registry -> assertThat(registry.algorithms())
-				.containsExactlyInAnyOrderElementsOf(JoseAlgorithm.DEFAULT_ALGORITHMS)));
+			.satisfies(registry -> {
+				assertThat(registry.algorithms())
+					.containsExactlyInAnyOrderElementsOf(JoseAlgorithm.DEFAULT_ALGORITHMS);
+				assertThat(registry.algorithms())
+					.doesNotContainAnyElementsOf(JoseAlgorithm.LEGACY_ALGORITHMS);
+			}));
+	}
 
+	@Test
+	@DisplayName("should not register legacy algorithms by default")
+	void shouldNotRegisterLegacyAlgorithmsByDefault() {
+		runner.run(ctx -> assertThat(ctx).hasNotFailed()
+			.doesNotHaveBean("legacyJoseAlgorithmRegistrar"));
+	}
+
+	@Test
+	@DisplayName("should register legacy algorithms when the opt-in property is set")
+	void shouldRegisterLegacyAlgorithmsWhenEnabled() {
+		runner.withPropertyValues("konfigyr.crypto.jose.register-legacy-algorithms=true")
+			.run(ctx -> assertThat(ctx).hasNotFailed()
+				.hasSingleBean(AlgorithmRegistry.class)
+				.getBean(AlgorithmRegistry.class)
+				.satisfies(registry -> assertThat(registry.algorithms())
+					.containsAll(JoseAlgorithm.LEGACY_ALGORITHMS)));
 	}
 
 }

--- a/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/AbstractKeysetFactoryTest.java
+++ b/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/AbstractKeysetFactoryTest.java
@@ -349,9 +349,9 @@ public abstract class AbstractKeysetFactoryTest {
 				.as("verify must reject empty signature for algorithm '%s'", label)
 				.isThrownBy(() -> keyset.verify(ByteArray.empty(), data));
 
-			 assertThatIllegalArgumentException()
-				 .as("verify must reject empty data for algorithm '%s'", label)
-				 .isThrownBy(() -> keyset.verify(signature, ByteArray.empty()));
+			assertThatIllegalArgumentException()
+				.as("verify must reject empty data for algorithm '%s'", label)
+				.isThrownBy(() -> keyset.verify(signature, ByteArray.empty()));
 		} else {
 			final ByteArray context = ByteArray.fromString("konfigyr-crypto-test-context");
 			final ByteArray cipher = keyset.encrypt(data);

--- a/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/AbstractKeysetFactoryTest.java
+++ b/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/AbstractKeysetFactoryTest.java
@@ -340,6 +340,18 @@ public abstract class AbstractKeysetFactoryTest {
 			assertThatExceptionOfType(CryptoException.UnsupportedKeysetOperationException.class)
 				.as("Keyset '%s' must reject decrypt on a signing keyset", keyset.getName())
 				.isThrownBy(() -> keyset.decrypt(data));
+
+			assertThatIllegalArgumentException()
+				.as("sign must reject empty data for algorithm '%s'", label)
+				.isThrownBy(() -> keyset.sign(ByteArray.empty()));
+
+			assertThatIllegalArgumentException()
+				.as("verify must reject empty signature for algorithm '%s'", label)
+				.isThrownBy(() -> keyset.verify(ByteArray.empty(), data));
+
+			 assertThatIllegalArgumentException()
+				 .as("verify must reject empty data for algorithm '%s'", label)
+				 .isThrownBy(() -> keyset.verify(signature, ByteArray.empty()));
 		} else {
 			final ByteArray context = ByteArray.fromString("konfigyr-crypto-test-context");
 			final ByteArray cipher = keyset.encrypt(data);
@@ -372,6 +384,14 @@ public abstract class AbstractKeysetFactoryTest {
 			assertThatExceptionOfType(CryptoException.UnsupportedKeysetOperationException.class)
 				.as("Keyset '%s' must reject verify on an encryption keyset", keyset.getName())
 				.isThrownBy(() -> keyset.verify(data, data));
+
+			assertThatIllegalArgumentException()
+				.as("encrypt must reject empty data for algorithm '%s'", label)
+				.isThrownBy(() -> keyset.encrypt(ByteArray.empty()));
+
+			assertThatIllegalArgumentException()
+				.as("decrypt must reject empty cipher for algorithm '%s'", label)
+				.isThrownBy(() -> keyset.decrypt(ByteArray.empty()));
 		}
 	}
 

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeyset.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeyset.java
@@ -45,6 +45,7 @@ class TinkKeyset extends AbstractKeyset<TinkKey> {
 
 	@Override
 	public ByteArray encrypt(ByteArray data, @Nullable ByteArray context) {
+		Assert.isTrue(!data.isEmpty(), "Cannot encrypt an empty byte array");
 		assertSupportedOperation(KeysetOperation.ENCRYPT);
 
 		final byte[] associatedData = context == null ? null : context.array();
@@ -69,6 +70,7 @@ class TinkKeyset extends AbstractKeyset<TinkKey> {
 
 	@Override
 	public ByteArray decrypt(ByteArray cipher, @Nullable ByteArray context) {
+		Assert.isTrue(!cipher.isEmpty(), "Cannot decrypt an empty byte array");
 		assertSupportedOperation(KeysetOperation.DECRYPT);
 
 		final byte[] associatedData = context == null ? null : context.array();
@@ -99,6 +101,7 @@ class TinkKeyset extends AbstractKeyset<TinkKey> {
 
 	@Override
 	public ByteArray sign(ByteArray data) {
+		Assert.isTrue(!data.isEmpty(), "Cannot sign an empty byte array");
 		assertSupportedOperation(KeysetOperation.SIGN);
 
 		final byte[] signature;
@@ -116,6 +119,8 @@ class TinkKeyset extends AbstractKeyset<TinkKey> {
 
 	@Override
 	public boolean verify(ByteArray signature, ByteArray data) {
+		Assert.isTrue(!signature.isEmpty(), "Cannot verify an empty signature");
+		Assert.isTrue(!data.isEmpty(), "Cannot verify a signature against an empty byte array");
 		assertSupportedOperation(KeysetOperation.VERIFY);
 
 		for (TinkKey key : prefixMap.getAllWithMatchingPrefix(signature.array())) {


### PR DESCRIPTION
- Flag RSA-PKCS1v1.5 signing algorithms (RS256, RS384, RS512) as legacy and register them using a conditional property: `konfigyr.crypto.jose.register-legacy-algorithms` to the registry
- Raise `RSA_OAEP_256` and `RSA_OAEP_384` key generation from 2048 to 3072 bits per NIST SP 800-131A Rev 2.
- Introduce `KeyEncryptionKey.format()` and use it in all log statements to ensure only the provider and key identifier are ever logged, never the KEK object itself.
- Add null/blank guards to all public `RepostoryKeysetStore` methods; reject destruction times in the past.
- Enforce the pattern [A-Za-z][A-Za-z0-9_]* on both table names in the `JdbcKeysetRepository`
- Emit a `WARN` on startup when `InMemoryKeysetRepository` is auto-configured, directing operators to `konfigyr-crypto-jdbc` or a custom `KeysetRepository`.