### PR TITLE
Introduce `WrappedKeyMaterial`, remove `Serializable` from encrypted keyset and key

### DIFF
--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKey.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKey.java
@@ -11,8 +11,6 @@ import org.springframework.core.io.InputStreamSource;
 import org.springframework.util.Assert;
 
 import java.io.InputStream;
-import java.io.Serial;
-import java.io.Serializable;
 import java.time.Instant;
 
 /**
@@ -35,10 +33,7 @@ import java.time.Instant;
  **/
 @Value
 @NullMarked
-public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource, Serializable {
-
-	@Serial
-	private static final long serialVersionUID = -7568519341937720112L;
+public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource {
 
 	/**
 	 * Unique identifier of this key within the encrypted keyset.
@@ -66,10 +61,12 @@ public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource
 	boolean primary;
 
 	/**
-	 * Encrypted cryptographic key material that was wrapped by the {@link KeyEncryptionKey}.
+	 * Wrapped cryptographic key material produced by {@link KeyEncryptionKey#wrap}. Is
+	 * {@literal null} when the key is in {@link KeyStatus#INITIALIZING} or
+	 * {@link KeyStatus#DESTROYED} state.
 	 */
 	@Nullable
-	ByteArray data;
+	WrappedKeyMaterial data;
 
 	/**
 	 * Timestamp that tells the time when this key was created.
@@ -123,7 +120,7 @@ public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource
 	 * Creates a new instance of the {@link Builder} pre-populated from an existing {@link EncryptedKey}.
 	 * <p>
 	 * All fields are copied as-is. Callers can then override individual fields (e.g. {@code status},
-	 * {@code destructionScheduledAt}) before calling {@link Builder#build(ByteArray)}.
+	 * {@code destructionScheduledAt}) before calling {@link Builder#build(WrappedKeyMaterial)}.
 	 *
 	 * @param existing the source {@link EncryptedKey} to copy, can't be {@literal null}
 	 * @return a pre-populated builder, never {@literal null}
@@ -143,14 +140,14 @@ public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource
 	}
 
 	/**
-	 * Creates a new instance of the {@link EncryptedKey} from the given {@link Key} and encrypted
-	 * key material represented by the {@link ByteArray}.
+	 * Creates a new instance of the {@link EncryptedKey} from the given {@link Key} and wrapped
+	 * key material produced by {@link KeyEncryptionKey#wrap}.
 	 *
 	 * @param key key that is encrypted by the {@link KeyEncryptionKey}, can't be {@literal null}
-	 * @param data encrypted private key material, if the key material is initialized
+	 * @param data wrapped key material, {@literal null} when the key material is not yet initialized
 	 * @return encrypted key, never {@literal  null}
 	 */
-	public static EncryptedKey from(Key key, @Nullable ByteArray data) {
+	public static EncryptedKey from(Key key, @Nullable WrappedKeyMaterial data) {
 		return builder()
 			.id(key.getId())
 			.algorithm(key.getAlgorithm())
@@ -305,14 +302,26 @@ public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource
 		}
 
 		/**
-		 * Creates a new instance of the {@link EncryptedKey} using the given {@link ByteArray} as the
-		 * encrypted key material from the matching {@link Key}.
+		 * Convenience overload that wraps the given {@link ByteArray} in a {@link WrappedKeyMaterial}
+		 * before delegating to {@link #build(WrappedKeyMaterial)}.
 		 *
-		 * @param data encrypted key material, can be {@literal null} if the key is not yet initialized
+		 * @param data key material bytes, can be {@literal null} if the key is not yet initialized
 		 * @return encrypted key
 		 * @throws IllegalArgumentException when required information to create the encrypted key is missing
 		 */
 		public EncryptedKey build(@Nullable ByteArray data) {
+			return build(data != null ? WrappedKeyMaterial.of(data) : null);
+		}
+
+		/**
+		 * Creates a new instance of the {@link EncryptedKey} using the given {@link WrappedKeyMaterial}
+		 * as the wrapped key material from the matching {@link Key}.
+		 *
+		 * @param data wrapped key material, can be {@literal null} if the key is not yet initialized
+		 * @return encrypted key
+		 * @throws IllegalArgumentException when required information to create the encrypted key is missing
+		 */
+		public EncryptedKey build(@Nullable WrappedKeyMaterial data) {
 			Assert.hasText(id, "Key identifier can not be blank");
 			Assert.hasText(algorithm, "Key algorithm can not be blank");
 			Assert.notNull(type, "Key type can not be null");

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKeyset.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKeyset.java
@@ -8,8 +8,6 @@ import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
-import java.io.Serial;
-import java.io.Serializable;
 import java.time.Duration;
 import java.util.*;
 
@@ -36,10 +34,7 @@ import java.util.*;
 @Value
 @NullMarked
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class EncryptedKeyset implements Iterable<EncryptedKey>, Serializable {
-
-	@Serial
-	private static final long serialVersionUID = -5051833454368671211L;
+public class EncryptedKeyset implements Iterable<EncryptedKey> {
 
 	/**
 	 * Unique keyset name.

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyEncryptionKey.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyEncryptionKey.java
@@ -46,24 +46,24 @@ public interface KeyEncryptionKey {
 	String getProvider();
 
 	/**
-	 * Wraps or encrypts the {@link Keyset} private material. The encryption algorithm that used to encrypt the
-	 * data depends on the implementation of the {@link KeyEncryptionKey}.
+	 * Wraps or encrypts the {@link Keyset} private material using this
+	 * {@link KeyEncryptionKey}. The encryption algorithm depends on the implementation.
 	 *
-	 * @param data private keyset material, can't be {@literal null}
-	 * @return encrypted private keyset material, never {@literal null}
+	 * @param data private keyset material to wrap, can't be {@literal null}
+	 * @return wrapped key material, never {@literal null}
 	 * @throws IOException when there is an issue while wrapping the private key material.
 	 */
-	ByteArray wrap(ByteArray data) throws IOException;
+	WrappedKeyMaterial wrap(ByteArray data) throws IOException;
 
 	/**
-	 * Unwraps or decrypts the {@link EncryptedKeyset} and returns the decrypted {@link ByteArray} containing
-	 * the private keyset material.
+	 * Unwraps or decrypts the given {@link WrappedKeyMaterial} and returns the plaintext
+	 * {@link ByteArray} containing the private keyset material.
 	 *
-	 * @param data encrypted keyset material to be unwrapped, can't be {@literal null}
+	 * @param data wrapped key material to unwrap, can't be {@literal null}
 	 * @return decrypted private keyset material, never {@literal null}
 	 * @throws IOException when there is an issue while unwrapping the encrypted private key material.
 	 */
-	ByteArray unwrap(ByteArray data) throws IOException;
+	ByteArray unwrap(WrappedKeyMaterial data) throws IOException;
 
 	/**
 	 * Formats the given {@link KeyEncryptionKey} as a safe log-friendly reference string

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetRepository.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetRepository.java
@@ -1,6 +1,5 @@
 package com.konfigyr.crypto;
 
-import com.konfigyr.io.ByteArray;
 import org.jspecify.annotations.NullMarked;
 
 import java.io.IOException;
@@ -74,7 +73,7 @@ public interface KeysetRepository {
 		final List<EncryptedKey> updatedKeys = new ArrayList<>(keyset.size());
 		for (EncryptedKey key : keyset) {
 			if (key.getId().equals(transition.getKeyId())) {
-				final ByteArray data = transition.getStatus() == KeyStatus.DESTROYED ? null : key.getData();
+				final WrappedKeyMaterial data = transition.getStatus() == KeyStatus.DESTROYED ? null : key.getData();
 				updatedKeys.add(EncryptedKey.builder(key)
 					.status(transition.getStatus())
 					.destructionScheduledAt(transition.getDestructionScheduledAt())

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/WrappedKeyMaterial.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/WrappedKeyMaterial.java
@@ -36,16 +36,6 @@ public final class WrappedKeyMaterial implements InputStreamSource {
 	}
 
 	/**
-	 * Creates a new {@link WrappedKeyMaterial} from the given raw byte array.
-	 *
-	 * @param bytes the wrapped key bytes, can't be {@literal null}
-	 * @return a new {@link WrappedKeyMaterial} instance, never {@literal null}
-	 */
-	public static WrappedKeyMaterial of(byte[] bytes) {
-		return of(new ByteArray(bytes));
-	}
-
-	/**
 	 * Creates a new {@link WrappedKeyMaterial} from the given {@link ByteArray}.
 	 *
 	 * @param bytes the wrapped key bytes, can't be {@literal null}
@@ -53,7 +43,18 @@ public final class WrappedKeyMaterial implements InputStreamSource {
 	 */
 	public static WrappedKeyMaterial of(ByteArray bytes) {
 		Assert.notNull(bytes, "Wrapped key material bytes can't be null");
+		Assert.isTrue(!bytes.isEmpty(), "Wrapped key material bytes can't be empty");
 		return new WrappedKeyMaterial(bytes);
+	}
+
+	/**
+	 * Creates a new {@link WrappedKeyMaterial} from the given raw byte array.
+	 *
+	 * @param bytes the wrapped key bytes, can't be {@literal null}
+	 * @return a new {@link WrappedKeyMaterial} instance, never {@literal null}
+	 */
+	public static WrappedKeyMaterial of(byte[] bytes) {
+		return of(new ByteArray(bytes));
 	}
 
 	/**

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/WrappedKeyMaterial.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/WrappedKeyMaterial.java
@@ -1,0 +1,105 @@
+package com.konfigyr.crypto;
+
+import com.konfigyr.io.ByteArray;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.core.io.InputStreamSource;
+import org.springframework.util.Assert;
+
+import java.io.InputStream;
+
+/**
+ * Immutable container for key material that has been wrapped (encrypted) by a
+ * {@link KeyEncryptionKey}. This type is the sole output of {@link KeyEncryptionKey#wrap}
+ * and the required input to {@link KeyEncryptionKey#unwrap}, making it impossible at the
+ * type level to pass raw plaintext bytes where wrapped material is expected, or to pass
+ * wrapped material where plaintext is expected.
+ * <p>
+ * Instances are intentionally not {@link java.io.Serializable}. Serializing wrapped key
+ * material to a remote store without an explicit, audited transport-security decision is a
+ * key-management risk. Callers that need persistence (e.g., a {@link KeysetRepository})
+ * must extract the underlying bytes via {@link #toByteArray()} and handle storage
+ * explicitly.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see KeyEncryptionKey
+ * @see EncryptedKey
+ */
+@NullMarked
+public final class WrappedKeyMaterial implements InputStreamSource {
+
+	private final ByteArray bytes;
+
+	private WrappedKeyMaterial(ByteArray bytes) {
+		this.bytes = bytes;
+	}
+
+	/**
+	 * Creates a new {@link WrappedKeyMaterial} from the given raw byte array.
+	 *
+	 * @param bytes the wrapped key bytes, can't be {@literal null}
+	 * @return a new {@link WrappedKeyMaterial} instance, never {@literal null}
+	 */
+	public static WrappedKeyMaterial of(byte[] bytes) {
+		return of(new ByteArray(bytes));
+	}
+
+	/**
+	 * Creates a new {@link WrappedKeyMaterial} from the given {@link ByteArray}.
+	 *
+	 * @param bytes the wrapped key bytes, can't be {@literal null}
+	 * @return a new {@link WrappedKeyMaterial} instance, never {@literal null}
+	 */
+	public static WrappedKeyMaterial of(ByteArray bytes) {
+		Assert.notNull(bytes, "Wrapped key material bytes can't be null");
+		return new WrappedKeyMaterial(bytes);
+	}
+
+	/**
+	 * Creates a new {@link WrappedKeyMaterial} from the given UTF-8 encoded string,
+	 * using {@link ByteArray#fromString(String)} for encoding.
+	 *
+	 * @param value the string to encode as wrapped key material, can't be {@literal null}
+	 * @return a new {@link WrappedKeyMaterial} instance, never {@literal null}
+	 */
+	public static WrappedKeyMaterial of(String value) {
+		return of(ByteArray.fromString(value));
+	}
+
+	/**
+	 * Returns the wrapped key bytes as a primitive byte array.
+	 * <p>
+	 * The returned value is intended for persistence (e.g., writing to a
+	 * {@link KeysetRepository}) or for passing back into {@link KeyEncryptionKey#unwrap}.
+	 * It must never be treated as or passed along as plaintext key material.
+	 *
+	 * @return the wrapped key bytes, never {@literal null}
+	 */
+	public byte[] toByteArray() {
+		return bytes.array();
+	}
+
+	@Override
+	public InputStream getInputStream() {
+		return bytes.getInputStream();
+	}
+
+	@Override
+	public boolean equals(@Nullable Object obj) {
+		if (this == obj) return true;
+		if (!(obj instanceof WrappedKeyMaterial other)) return false;
+		return bytes.equals(other.bytes);
+	}
+
+	@Override
+	public int hashCode() {
+		return bytes.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "WrappedKeyMaterial[" + bytes.size() + " bytes]";
+	}
+
+}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeyTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeyTest.java
@@ -2,10 +2,11 @@ package com.konfigyr.crypto;
 
 import com.konfigyr.crypto.test.EncryptedKeyAssert;
 import com.konfigyr.crypto.test.TestAlgorithm;
-import com.konfigyr.io.ByteArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.*;
@@ -15,7 +16,7 @@ import static org.mockito.Mockito.mock;
 class EncryptedKeyTest {
 
 	static final Algorithm algorithm = TestAlgorithm.INSTANCE;
-	static final ByteArray data = ByteArray.fromString("encrypted-key-material");
+	static final WrappedKeyMaterial data = WrappedKeyMaterial.of("encrypted-key-material");
 	static final Instant now = Instant.parse("2026-01-01T00:00:00Z");
 
 	@Test
@@ -77,11 +78,11 @@ class EncryptedKeyTest {
 			.primary(false)
 			.createdAt(now)
 			.destroyedAt(now)
-			.build(null);
+			.build((WrappedKeyMaterial) null);
 
 		EncryptedKeyAssert.assertThat(key)
 			.hasStatus(KeyStatus.DESTROYED)
-			.hasMaterial((ByteArray) null)
+			.hasMaterial((WrappedKeyMaterial) null)
 			.isDestroyedAt(now);
 	}
 
@@ -131,7 +132,7 @@ class EncryptedKeyTest {
 			.build(data);
 
 		assertThat(key.getInputStream())
-			.hasBinaryContent(data.array());
+			.hasBinaryContent(data.toByteArray());
 	}
 
 	@Test
@@ -142,7 +143,7 @@ class EncryptedKeyTest {
 			.algorithm(algorithm)
 			.status(KeyStatus.DESTROYED)
 			.createdAt(now)
-			.build(null);
+			.build((WrappedKeyMaterial) null);
 
 		assertThat(key.getInputStream())
 			.hasBinaryContent(new byte[0]);
@@ -232,6 +233,23 @@ class EncryptedKeyTest {
 				.status(KeyStatus.ENABLED)
 				.build(data))
 			.withMessage("Key creation time can not be null");
+	}
+
+	@Test
+	@DisplayName("should not be Java-serializable")
+	void shouldNotBeSerializable() {
+		final var key = EncryptedKey.builder()
+			.id("key-id")
+			.algorithm(algorithm)
+			.status(KeyStatus.ENABLED)
+			.createdAt(now)
+			.build(data);
+
+		assertThatThrownBy(() -> {
+			try (var out = new ObjectOutputStream(new ByteArrayOutputStream())) {
+				out.writeObject(key);
+			}
+		}).isInstanceOf(java.io.NotSerializableException.class);
 	}
 
 }

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeyTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeyTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 import java.time.Instant;
 
@@ -245,11 +246,11 @@ class EncryptedKeyTest {
 			.createdAt(now)
 			.build(data);
 
-		assertThatThrownBy(() -> {
+		assertThatExceptionOfType(NotSerializableException.class).isThrownBy(() -> {
 			try (var out = new ObjectOutputStream(new ByteArrayOutputStream())) {
 				out.writeObject(key);
 			}
-		}).isInstanceOf(java.io.NotSerializableException.class);
+		});
 	}
 
 }

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeysetTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeysetTest.java
@@ -7,6 +7,8 @@ import com.konfigyr.io.ByteArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -293,6 +295,22 @@ class EncryptedKeysetTest {
 				.provider("test-provider")
 				.build())
 			.withMessage("KEK identifier can not be blank");
+	}
+
+	@Test
+	@DisplayName("should not be Java-serializable")
+	void shouldNotBeSerializable() {
+		assertThatThrownBy(() -> {
+			try (var out = new ObjectOutputStream(new ByteArrayOutputStream())) {
+				out.writeObject(EncryptedKeyset.builder()
+					.name("test-keyset")
+					.purpose(KeysetPurpose.ENCRYPTION)
+					.factory("test-factory")
+					.provider("test-provider")
+					.keyEncryptionKey("test-kek")
+					.build());
+			}
+		}).isInstanceOf(java.io.NotSerializableException.class);
 	}
 
 }

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeysetTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeysetTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 import java.time.Duration;
 import java.time.Instant;
@@ -300,7 +301,7 @@ class EncryptedKeysetTest {
 	@Test
 	@DisplayName("should not be Java-serializable")
 	void shouldNotBeSerializable() {
-		assertThatThrownBy(() -> {
+		assertThatExceptionOfType(NotSerializableException.class).isThrownBy(() -> {
 			try (var out = new ObjectOutputStream(new ByteArrayOutputStream())) {
 				out.writeObject(EncryptedKeyset.builder()
 					.name("test-keyset")
@@ -310,7 +311,7 @@ class EncryptedKeysetTest {
 					.keyEncryptionKey("test-kek")
 					.build());
 			}
-		}).isInstanceOf(java.io.NotSerializableException.class);
+		});
 	}
 
 }

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/WrappedKeyMaterialTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/WrappedKeyMaterialTest.java
@@ -1,0 +1,111 @@
+package com.konfigyr.crypto;
+
+import com.konfigyr.io.ByteArray;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.NotSerializableException;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.*;
+
+class WrappedKeyMaterialTest {
+
+	@Test
+	@DisplayName("should create WrappedKeyMaterial from ByteArray")
+	void shouldCreateWrappedKeyMaterialFromByteArray() {
+		final var bytes = ByteArray.fromString("test-key-material");
+
+		assertThat(WrappedKeyMaterial.of(bytes))
+			.isNotNull()
+			.returns(bytes.array(), WrappedKeyMaterial::toByteArray);
+	}
+
+	@Test
+	@DisplayName("should create WrappedKeyMaterial from primitive byte array")
+	void shouldCreateWrappedKeyMaterialFromPrimitiveByteArray() {
+		final var bytes = "test-key-material".getBytes();
+
+		assertThat(WrappedKeyMaterial.of(bytes))
+			.isNotNull()
+			.returns(bytes, WrappedKeyMaterial::toByteArray);
+	}
+
+	@Test
+	@DisplayName("should create WrappedKeyMaterial from String")
+	void shouldCreateWrappedKeyMaterialFromString() {
+		final var value = "test-key-material";
+
+		assertThat(WrappedKeyMaterial.of(value))
+			.isNotNull()
+			.returns(value.getBytes(StandardCharsets.UTF_8), WrappedKeyMaterial::toByteArray);
+	}
+
+	@Test
+	@DisplayName("should throw exception when ByteArray is null or empty")
+	void shouldThrowExceptionWhenByteArrayIsEmpty() {
+		assertThatThrownBy(() -> WrappedKeyMaterial.of(ByteArray.empty()))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Wrapped key material bytes can't be empty");
+	}
+
+	@Test
+	@DisplayName("should return a copy of byte array from toByteArray()")
+	void shouldReturnByteArrayFromToByteArray() {
+		byte[] originalBytes = "test-key-material".getBytes();
+
+		assertThat(WrappedKeyMaterial.of(originalBytes).toByteArray())
+			.isEqualTo(originalBytes)
+			.isNotSameAs(originalBytes);
+	}
+
+	@Test
+	@DisplayName("should open an InputStream from the provided byte array")
+	void shouldReturnByteArrayFromInputStream() {
+		byte[] originalBytes = "test-key-material".getBytes();
+
+		assertThat(WrappedKeyMaterial.of(originalBytes).getInputStream())
+			.hasBinaryContent(originalBytes);
+	}
+
+	@Test
+	@DisplayName("should implement equals() and hashCode() correctly")
+	void shouldImplementEqualsAndHashCode() {
+		byte[] bytes = "test-key-material".getBytes();
+		WrappedKeyMaterial material1 = WrappedKeyMaterial.of(bytes);
+		WrappedKeyMaterial material2 = WrappedKeyMaterial.of(bytes);
+		WrappedKeyMaterial material3 = WrappedKeyMaterial.of("different-material".getBytes());
+
+		assertThat(material1)
+			.isEqualTo(material2)
+			.isNotEqualTo(material3)
+			.isNotEqualTo(null)
+			.isNotEqualTo("some-string");
+
+		assertThat(material1)
+			.hasSameHashCodeAs(material2)
+			.doesNotHaveSameHashCodeAs(material3);
+	}
+
+	@Test
+	@DisplayName("should return formatted string from toString()")
+	void shouldReturnFormattedStringFromToString() {
+		byte[] bytes = "test-key-material".getBytes();
+
+		assertThat(WrappedKeyMaterial.of(bytes))
+			.hasToString("WrappedKeyMaterial[%d bytes]", bytes.length);
+	}
+
+	@Test
+	@DisplayName("should not be Java-serializable")
+	void shouldNotBeSerializable() {
+		assertThatExceptionOfType(NotSerializableException.class).isThrownBy(() -> {
+			try (var out = new ObjectOutputStream(new ByteArrayOutputStream())) {
+				out.writeObject(WrappedKeyMaterial.of("test-key-material"));
+			}
+		});
+	}
+
+}

--- a/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
+++ b/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
@@ -1,6 +1,7 @@
 package com.konfigyr.crypto.jdbc;
 
 import com.konfigyr.crypto.*;
+import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -576,11 +577,10 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 		}
 	}
 
-	private static void setBytes(PreparedStatement ps, int index, @Nullable ByteArray data) throws SQLException {
+	private static void setBytes(PreparedStatement ps, int index, @Nullable WrappedKeyMaterial data) throws SQLException {
 		if (data != null) {
-			ps.setBytes(index, data.array());
-		}
-		else {
+			ps.setBytes(index, data.toByteArray());
+		} else {
 			ps.setNull(index, Types.BINARY);
 		}
 	}

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseKeysetFactory.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseKeysetFactory.java
@@ -1,6 +1,7 @@
 package com.konfigyr.crypto.jose;
 
 import com.konfigyr.crypto.*;
+import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
 import com.nimbusds.jose.jwk.JWK;
 import lombok.RequiredArgsConstructor;
@@ -64,7 +65,7 @@ public class JoseKeysetFactory implements KeysetFactory {
 		final List<EncryptedKey> keys = new ArrayList<>(keyset.getKeys().size());
 
 		for (Key key : keyset.getKeys()) {
-			final ByteArray encrypted;
+			final WrappedKeyMaterial encrypted;
 
 			try {
 				final JWK value = ((JsonWebKey) key).getValue();

--- a/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/AbstractKeysetFactoryTest.java
+++ b/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/AbstractKeysetFactoryTest.java
@@ -1,6 +1,7 @@
 package com.konfigyr.crypto.test;
 
 import com.konfigyr.crypto.*;
+import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.DisplayName;
@@ -75,12 +76,12 @@ public abstract class AbstractKeysetFactoryTest {
 	protected KeyEncryptionKey wrongKek() {
 		return new AbstractKeyEncryptionKey("wrong-kek", kek().getProvider()) {
 			@Override
-			public ByteArray wrap(ByteArray data) {
-				return data;
+			public WrappedKeyMaterial wrap(ByteArray data) {
+				return WrappedKeyMaterial.of(data);
 			}
 
 			@Override
-			public ByteArray unwrap(ByteArray data) {
+			public ByteArray unwrap(WrappedKeyMaterial data) {
 				throw new CryptoException.UnwrappingException("unknown", this,
 					new IllegalStateException("wrong key encryption key"));
 			}
@@ -412,14 +413,14 @@ public abstract class AbstractKeysetFactoryTest {
 
 			for (int j = 0; j < history.size(); j++) {
 				assertCryptoAccess(purpose, keyset, history.get(j), data,
-					"after rotation #" + i + ", must still access data produced in step #" + j);
+					label + ": after rotation #" + i + ", must still access data produced in step #" + j);
 			}
 
 			keyset = decryptKeyset(encryptKeyset(keyset));
 
 			for (int j = 0; j < history.size(); j++) {
 				assertCryptoAccess(purpose, keyset, history.get(j), data,
-					"after round-trip following rotation #" + i + ", must still access data produced in step #" + j);
+					label + ": after round-trip following rotation #" + i + ", must still access data produced in step #" + j);
 			}
 		}
 	}

--- a/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/EncryptedKeyAssert.java
+++ b/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/EncryptedKeyAssert.java
@@ -1,6 +1,7 @@
 package com.konfigyr.crypto.test;
 
 import com.konfigyr.crypto.*;
+import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
@@ -13,6 +14,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
+@SuppressWarnings("unused")
 public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert, EncryptedKey> {
 
 	public static InstanceOfAssertFactory<EncryptedKey, EncryptedKeyAssert> factory() {
@@ -99,10 +101,14 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	}
 
 	public EncryptedKeyAssert hasMaterial(String material) {
-		return hasMaterial(material == null ? null : ByteArray.fromString(material));
+		return hasMaterial(material == null ? null : WrappedKeyMaterial.of(material));
 	}
 
 	public EncryptedKeyAssert hasMaterial(ByteArray material) {
+		return hasMaterial(material == null ? null : WrappedKeyMaterial.of(material));
+	}
+
+	public EncryptedKeyAssert hasMaterial(WrappedKeyMaterial material) {
 		isNotNull();
 		if (!Objects.equals(actual.getData(), material)) {
 			failWithMessage("Expected key to have key material of <%s> but was <%s>",

--- a/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/TestKeyEncryptionKey.java
+++ b/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/TestKeyEncryptionKey.java
@@ -2,6 +2,7 @@ package com.konfigyr.crypto.test;
 
 import com.konfigyr.crypto.AbstractKeyEncryptionKey;
 import com.konfigyr.crypto.KeyEncryptionKey;
+import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
 import org.jspecify.annotations.NullMarked;
 
@@ -68,7 +69,7 @@ public class TestKeyEncryptionKey extends AbstractKeyEncryptionKey {
 	 * @throws IOException when encryption fails
 	 */
 	@Override
-	public ByteArray wrap(ByteArray data) throws IOException {
+	public WrappedKeyMaterial wrap(ByteArray data) throws IOException {
 		try {
 			final byte[] iv = new byte[IV_LENGTH];
 			new SecureRandom().nextBytes(iv);
@@ -81,7 +82,7 @@ public class TestKeyEncryptionKey extends AbstractKeyEncryptionKey {
 			System.arraycopy(iv, 0, result, 0, IV_LENGTH);
 			System.arraycopy(ciphertext, 0, result, IV_LENGTH, ciphertext.length);
 
-			return new ByteArray(result);
+			return WrappedKeyMaterial.of(result);
 		} catch (GeneralSecurityException e) {
 			throw new IOException("Failed to wrap key material using AES-256-GCM", e);
 		}
@@ -96,9 +97,9 @@ public class TestKeyEncryptionKey extends AbstractKeyEncryptionKey {
 	 * @throws IOException when decryption or authentication fails
 	 */
 	@Override
-	public ByteArray unwrap(ByteArray data) throws IOException {
+	public ByteArray unwrap(WrappedKeyMaterial data) throws IOException {
 		try {
-			final byte[] raw = data.array();
+			final byte[] raw = data.toByteArray();
 			final byte[] iv = Arrays.copyOfRange(raw, 0, IV_LENGTH);
 			final byte[] ciphertext = Arrays.copyOfRange(raw, IV_LENGTH, raw.length);
 

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeyEncryptionKey.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeyEncryptionKey.java
@@ -13,6 +13,7 @@ import com.google.crypto.tink.subtle.Random;
 import com.konfigyr.crypto.AbstractKeyEncryptionKey;
 import com.konfigyr.crypto.KeyEncryptionKey;
 import com.konfigyr.crypto.Keyset;
+import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
 import org.jspecify.annotations.NonNull;
 import org.springframework.util.Assert;
@@ -43,9 +44,9 @@ public class TinkKeyEncryptionKey extends AbstractKeyEncryptionKey {
 
 	@NonNull
 	@Override
-	public ByteArray wrap(@NonNull ByteArray data) throws IOException {
+	public WrappedKeyMaterial wrap(@NonNull ByteArray data) throws IOException {
 		try {
-			return new ByteArray(factory.get().encrypt(data.array(), null));
+			return WrappedKeyMaterial.of(factory.get().encrypt(data.array(), null));
 		}
 		catch (GeneralSecurityException e) {
 			throw new IOException("Failed to encrypt private key material", e);
@@ -54,9 +55,9 @@ public class TinkKeyEncryptionKey extends AbstractKeyEncryptionKey {
 
 	@NonNull
 	@Override
-	public ByteArray unwrap(@NonNull ByteArray data) throws IOException {
+	public ByteArray unwrap(@NonNull WrappedKeyMaterial data) throws IOException {
 		try {
-			return new ByteArray(factory.get().decrypt(data.array(), null));
+			return new ByteArray(factory.get().decrypt(data.toByteArray(), null));
 		}
 		catch (GeneralSecurityException e) {
 			throw new IOException("Failed to decrypt private key material", e);

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeysetFactory.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeysetFactory.java
@@ -8,6 +8,7 @@ import com.google.crypto.tink.proto.OutputPrefixType;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.konfigyr.crypto.*;
 import com.konfigyr.crypto.Key;
+import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
@@ -69,7 +70,7 @@ public class TinkKeysetFactory implements KeysetFactory {
 		final List<EncryptedKey> keys = new ArrayList<>(keyset.getKeys().size());
 
 		for (Key key : keyset.getKeys()) {
-			final ByteArray encrypted;
+			final WrappedKeyMaterial encrypted;
 
 			try {
 				final ProtoKeySerialization serialization = MutableSerializationRegistry.globalInstance()


### PR DESCRIPTION
 - Add `WrappedKeyMaterial`, an immutable, non-serializable type that is the sole output of `KeyEncryptionKey.wrap()` and required input of `unwrap()`, making it a compile-time error to pass plaintext bytes where wrapped material is expected 
 - Remove `Serializable` from `EncryptedKey` and `EncryptedKeyset` to prevent accidental serialization of key material to remote caches or session stores
- Add `EncryptedKey.Builder.build(ByteArray)` convenience overload that wraps transparently, reducing call-site noise at factory and test boundaries