### PR TITLE
Enforce key lifecycle transitions via `KeyStatus#canTransitionTo(KeyStatus)`

### DIFF
--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyStatus.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyStatus.java
@@ -1,15 +1,18 @@
 package com.konfigyr.crypto;
 
+import java.util.EnumMap;
+import java.util.Set;
+
 /**
  * Defines the lifecycle status of a {@link Key}.
  * <p>
  * Keys transition through statuses over their lifetime. Only {@link #ENABLED} keys
  * participate in cryptographic operations. The full lifecycle is:
  * <pre>
- * INITIALIZING ──► ENABLED ──► COMPROMISED
- *       │                  └──► DISABLED ──► PENDING_DESTRUCTION ──► DESTROYED
- *       │                                                         └──► DESTRUCTION_FAILED
- *       └──► INITIALIZATION_FAILED
+ * INITIALIZING ──► ENABLED ──► DISABLED ──► ENABLED
+ *       │               │           └──► COMPROMISED ──► PENDING_DESTRUCTION ──► DISABLED
+ *       │               └──► COMPROMISED ──┘                                 ├──► DESTROYED
+ *       └──► INITIALIZATION_FAILED                                            └──► DESTRUCTION_FAILED
  * </pre>
  *
  * @author Vladimir Spasic
@@ -64,6 +67,21 @@ public enum KeyStatus {
 	 * An attempt to destroy the key material failed. No cryptographic operations are
 	 * permitted. Manual intervention is required to complete destruction.
 	 */
-	DESTRUCTION_FAILED
+	DESTRUCTION_FAILED;
+
+	static final EnumMap<KeyStatus, Set<KeyStatus>> SUPPORTED_TRANSITIONS = new EnumMap<>(KeyStatus.class);
+
+	static {
+		SUPPORTED_TRANSITIONS.put(INITIALIZING, Set.of(ENABLED, INITIALIZATION_FAILED));
+		SUPPORTED_TRANSITIONS.put(ENABLED, Set.of(COMPROMISED, DISABLED, PENDING_DESTRUCTION, DESTROYED));
+		SUPPORTED_TRANSITIONS.put(COMPROMISED, Set.of(DISABLED, PENDING_DESTRUCTION, DESTROYED));
+		SUPPORTED_TRANSITIONS.put(DISABLED, Set.of(ENABLED, COMPROMISED, PENDING_DESTRUCTION, DESTROYED));
+		SUPPORTED_TRANSITIONS.put(PENDING_DESTRUCTION, Set.of(DISABLED, DESTROYED, DESTRUCTION_FAILED));
+	}
+
+	public boolean canTransitionTo(KeyStatus target) {
+		final Set<KeyStatus> allowedTransitions = SUPPORTED_TRANSITIONS.get(this);
+		return allowedTransitions != null && allowedTransitions.contains(target);
+	}
 
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyTransition.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyTransition.java
@@ -102,11 +102,12 @@ public class KeyTransition {
 	}
 
 	/**
-	 * Creates a transition that moves a key from {@link KeyStatus#ENABLED} to
-	 * {@link KeyStatus#COMPROMISED}.
+	 * Creates a transition that moves a key from {@link KeyStatus#ENABLED} or
+	 * {@link KeyStatus#DISABLED} to {@link KeyStatus#COMPROMISED}.
 	 * <p>
-	 * This is an irreversible emergency transition. Once compromised, the key cannot
-	 * be re-enabled or used for any cryptographic operation.
+	 * This is an emergency transition. Once compromised, the key cannot be re-enabled or
+	 * used for any cryptographic operation. Key material should subsequently be scheduled
+	 * for destruction via {@link KeysetStore#scheduleDestruction(String, String)}.
 	 *
 	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
 	 * @param keyId the identifier of the key to mark as compromised, can't be {@literal null}

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetStore.java
@@ -266,35 +266,37 @@ public interface KeysetStore {
 	void enable(String keysetName, String keyId);
 
 	/**
-	 * Transitions the specified {@link Key} within the named {@link Keyset} from
-	 * {@link KeyStatus#ENABLED} to {@link KeyStatus#COMPROMISED}.
+	 * Transitions the specified {@link Key} within the named {@link Keyset} to
+	 * {@link KeyStatus#COMPROMISED}.
 	 * <p>
 	 * A compromised key is suspected or confirmed to have had its material exposed. All
 	 * cryptographic operations on the key are permanently hard-blocked after this call.
-	 * This transition is irreversible, a compromised key cannot be re-enabled or moved
-	 * to any other lifecycle state via the normal state machine.
+	 * The key must be in {@link KeyStatus#ENABLED} or {@link KeyStatus#DISABLED} state,
+	 * re-enabling a disabled key solely to mark it compromised is never required.
 	 * <p>
 	 * Callers should follow this with a {@link #rotate(String)} to generate a new primary
 	 * key for the keyset and arrange for re-encryption of data protected by the compromised key.
+	 * To erase the key material, call {@link #scheduleDestruction(String, String)} after this.
 	 *
 	 * @param keysetName the name of the keyset containing the key, can't be {@literal null}
 	 * @param keyId      the identifier of the key to mark as compromised, can't be {@literal null}
 	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
 	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
-	 *         in {@link KeyStatus#ENABLED} state
+	 *         in {@link KeyStatus#ENABLED} or {@link KeyStatus#DISABLED} state
 	 * @throws CryptoException.KeysetCompromisedException when a keyset whose primary key is
 	 *         {@link KeyStatus#COMPROMISED} is subsequently accessed for cryptographic operations
 	 */
 	void compromise(String keysetName, String keyId);
 
 	/**
-	 * Transitions the specified {@link Key} within the named {@link Keyset} from
-	 * {@link KeyStatus#DISABLED} to {@link KeyStatus#PENDING_DESTRUCTION}, using the keyset's
-	 * configured {@link Keyset#getDestructionGracePeriod() destruction grace period} to compute
-	 * the scheduled destruction time.
+	 * Transitions the specified {@link Key} within the named {@link Keyset} to
+	 * {@link KeyStatus#PENDING_DESTRUCTION}, using the keyset's configured
+	 * {@link Keyset#getDestructionGracePeriod() destruction grace period} to compute the
+	 * scheduled destruction time.
 	 * <p>
-	 * Requires the key to be in {@link KeyStatus#DISABLED} state first (two-step deactivation
-	 * before destruction, per NIST SP 800-57 §8.3.1).
+	 * The key must be in {@link KeyStatus#DISABLED} or {@link KeyStatus#COMPROMISED} state.
+	 * Accepting {@link KeyStatus#COMPROMISED} directly satisfies NIST SP 800-57 §8.2.9 —
+	 * compromised key material must be destroyable without requiring re-activation.
 	 * <p>
 	 * When the keyset has no destruction grace period configured ({@literal null}), the key
 	 * material is destroyed immediately: the key is transitioned through
@@ -309,24 +311,24 @@ public interface KeysetStore {
 	 * @param keyId      the identifier of the key to schedule for destruction, can't be {@literal null}
 	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
 	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
-	 *         in {@link KeyStatus#DISABLED} state
+	 *         in {@link KeyStatus#DISABLED} or {@link KeyStatus#COMPROMISED} state
 	 */
 	void scheduleDestruction(String keysetName, String keyId);
 
 	/**
-	 * Transitions the specified {@link Key} within the named {@link Keyset} from
-	 * {@link KeyStatus#DISABLED} to {@link KeyStatus#PENDING_DESTRUCTION}, with an explicit
-	 * scheduled destruction time.
+	 * Transitions the specified {@link Key} within the named {@link Keyset} to
+	 * {@link KeyStatus#PENDING_DESTRUCTION}, with an explicit scheduled destruction time.
 	 * <p>
-	 * Requires the key to be in {@link KeyStatus#DISABLED} state first (two-step deactivation
-	 * before destruction, per NIST SP 800-57 §8.3.1).
+	 * The key must be in {@link KeyStatus#DISABLED} or {@link KeyStatus#COMPROMISED} state.
+	 * Accepting {@link KeyStatus#COMPROMISED} directly satisfies NIST SP 800-57 §8.2.9 —
+	 * compromised key material must be destroyable without requiring re-activation.
 	 *
 	 * @param keysetName      the name of the keyset containing the key, can't be {@literal null}
 	 * @param keyId           the identifier of the key to schedule for destruction, can't be {@literal null}
 	 * @param destructionTime the time at which destruction should occur, can't be {@literal null}
 	 * @throws CryptoException.KeysetNotFoundException when no keyset exists with the given name
 	 * @throws CryptoException.InvalidKeyStatusTransitionException when the key is not currently
-	 *         in {@link KeyStatus#DISABLED} state
+	 *         in {@link KeyStatus#DISABLED} or {@link KeyStatus#COMPROMISED} state
 	 */
 	void scheduleDestruction(String keysetName, String keyId, Instant destructionTime);
 

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepostoryKeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepostoryKeysetStore.java
@@ -161,7 +161,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 		Assert.hasText(keysetName, "Keyset name must not be blank");
 		Assert.hasText(keyId, "Key ID must not be blank");
 
-		performKeyTransition(KeyTransition.disable(keysetName, keyId), KeyStatus.ENABLED);
+		performKeyTransition(KeyTransition.disable(keysetName, keyId));
 	}
 
 	@Override
@@ -169,7 +169,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 		Assert.hasText(keysetName, "Keyset name must not be blank");
 		Assert.hasText(keyId, "Key ID must not be blank");
 
-		performKeyTransition(KeyTransition.enable(keysetName, keyId), KeyStatus.DISABLED);
+		performKeyTransition(KeyTransition.enable(keysetName, keyId));
 	}
 
 	@Override
@@ -177,7 +177,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 		Assert.hasText(keysetName, "Keyset name must not be blank");
 		Assert.hasText(keyId, "Key ID must not be blank");
 
-		performKeyTransition(KeyTransition.compromise(keysetName, keyId), KeyStatus.ENABLED);
+		performKeyTransition(KeyTransition.compromise(keysetName, keyId));
 	}
 
 	@Override
@@ -191,8 +191,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 				? Instant.now().plus(gracePeriod)
 				: Instant.now();
 
-		performKeyTransition(KeyTransition.scheduleDestruction(keysetName, keyId, destructionTime),
-				KeyStatus.DISABLED);
+		performKeyTransition(KeyTransition.scheduleDestruction(keysetName, keyId, destructionTime));
 
 		if (gracePeriod == null) {
 			destroy(keysetName, keyId);
@@ -205,8 +204,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 		Assert.hasText(keyId, "Key ID must not be blank");
 		Assert.isTrue(destructionTime.isAfter(Instant.now()), "Destruction time must be in the future");
 
-		performKeyTransition(KeyTransition.scheduleDestruction(keysetName, keyId, destructionTime),
-				KeyStatus.DISABLED);
+		performKeyTransition(KeyTransition.scheduleDestruction(keysetName, keyId, destructionTime));
 	}
 
 	@Override
@@ -214,8 +212,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 		Assert.hasText(keysetName, "Keyset name must not be blank");
 		Assert.hasText(keyId, "Key ID must not be blank");
 
-		performKeyTransition(KeyTransition.cancelDestruction(keysetName, keyId),
-				KeyStatus.PENDING_DESTRUCTION);
+		performKeyTransition(KeyTransition.cancelDestruction(keysetName, keyId));
 	}
 
 	@Override
@@ -223,15 +220,15 @@ public class RepostoryKeysetStore implements KeysetStore {
 		Assert.hasText(keysetName, "Keyset name must not be blank");
 		Assert.hasText(keyId, "Key ID must not be blank");
 
-		performKeyTransition(KeyTransition.destroy(keysetName, keyId, Instant.now()),
-				KeyStatus.PENDING_DESTRUCTION);
+		performKeyTransition(KeyTransition.destroy(keysetName, keyId, Instant.now()));
 	}
 
 	/**
-	 * Looks up the key within the keyset, validates the status transition, delegates to the
-	 * repository, and evicts the cache entry.
+	 * Looks up the key within the keyset, validates the status transition using
+	 * {@link KeyStatus#canTransitionTo(KeyStatus)}, delegates to the repository, and evicts
+	 * the cache entry.
 	 */
-	private void performKeyTransition(KeyTransition transition, KeyStatus expected) {
+	private void performKeyTransition(KeyTransition transition) {
 		final String keysetName = transition.getKeysetName();
 		final String keyId = transition.getKeyId();
 
@@ -240,14 +237,14 @@ public class RepostoryKeysetStore implements KeysetStore {
 			() -> new KeysetException(keysetName, "Key '" + keyId + "' was not found in keyset '" + keysetName + "'.")
 		);
 
-		if (key.getStatus() != expected) {
+		if (!key.getStatus().canTransitionTo(transition.getStatus())) {
 			throw new InvalidKeyStatusTransitionException(keysetName, keyId, key.getStatus(),
 					transition.getStatus());
 		}
 
 		if (logger.isDebugEnabled()) {
 			logger.debug("Transitioning key '{}' in keyset '{}' from {} to {}", keyId, keysetName,
-					expected, transition.getStatus());
+					key.getStatus(), transition.getStatus());
 		}
 
 		try {

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/KeyStatusSanityTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/KeyStatusSanityTest.java
@@ -1,0 +1,75 @@
+package com.konfigyr.crypto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.konfigyr.crypto.KeyStatus.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeyStatusSanityTest {
+
+	@MethodSource("supportedTransitions")
+	@ParameterizedTest(name = "{0} → {1}")
+	@DisplayName("should allow every documented lifecycle transition")
+	void shouldAllowSupportedTransition(KeyStatus from, KeyStatus to) {
+		assertThat(from.canTransitionTo(to))
+			.as("Expected %s → %s to be allowed", from, to)
+			.isTrue();
+	}
+
+	@MethodSource("unsupportedTransitions")
+	@ParameterizedTest(name = "{0} → {1}")
+	@DisplayName("should reject every undocumented or terminal-state transition")
+	void shouldRejectUnsupportedTransition(KeyStatus from, KeyStatus to) {
+		assertThat(from.canTransitionTo(to))
+			.as("Expected %s → %s to be rejected", from, to)
+			.isFalse();
+	}
+
+	static Stream<Arguments> supportedTransitions() {
+		return Stream.of(
+			Arguments.of(INITIALIZING, ENABLED),
+			Arguments.of(INITIALIZING, INITIALIZATION_FAILED),
+			Arguments.of(ENABLED, COMPROMISED),
+			Arguments.of(ENABLED, DISABLED),
+			Arguments.of(ENABLED, PENDING_DESTRUCTION),
+			Arguments.of(ENABLED, DESTROYED),
+			Arguments.of(COMPROMISED, DISABLED),
+			Arguments.of(COMPROMISED, PENDING_DESTRUCTION),
+			Arguments.of(COMPROMISED, DESTROYED),
+			Arguments.of(DISABLED, ENABLED),
+			Arguments.of(DISABLED, COMPROMISED),
+			Arguments.of(DISABLED, PENDING_DESTRUCTION),
+			Arguments.of(DISABLED, DESTROYED),
+			Arguments.of(PENDING_DESTRUCTION, DISABLED),
+			Arguments.of(PENDING_DESTRUCTION, DESTROYED),
+			Arguments.of(PENDING_DESTRUCTION, DESTRUCTION_FAILED)
+		);
+	}
+
+	static Stream<Arguments> unsupportedTransitions() {
+		return Stream.of(
+			// Terminal states — no outgoing transitions
+			Arguments.of(DESTROYED, ENABLED),
+			Arguments.of(DESTROYED, DISABLED),
+			Arguments.of(DESTROYED, PENDING_DESTRUCTION),
+			Arguments.of(INITIALIZATION_FAILED, ENABLED),
+			Arguments.of(INITIALIZATION_FAILED, INITIALIZING),
+			Arguments.of(DESTRUCTION_FAILED, DESTROYED),
+			Arguments.of(DESTRUCTION_FAILED, PENDING_DESTRUCTION),
+			// PENDING_DESTRUCTION may only move to DISABLED (cancel), DESTROYED, or DESTRUCTION_FAILED
+			Arguments.of(PENDING_DESTRUCTION, ENABLED),
+			Arguments.of(PENDING_DESTRUCTION, COMPROMISED),
+			// COMPROMISED cannot be re-enabled
+			Arguments.of(COMPROMISED, ENABLED),
+			// No self-loops
+			Arguments.of(ENABLED, ENABLED),
+			Arguments.of(DISABLED, DISABLED)
+		);
+	}
+
+}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepositoryKeysetStoreTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepositoryKeysetStoreTest.java
@@ -459,15 +459,26 @@ class RepositoryKeysetStoreTest {
 	}
 
 	@Test
-	@DisplayName("should throw InvalidKeyStatusTransitionException when compromising a non-ENABLED key")
-	void shouldFailToCompromiseNonEnabledKey() throws IOException {
+	@DisplayName("should mark a DISABLED key as compromised and evict the cache")
+	void shouldCompromiseDisabledKey() throws IOException {
 		repository.write(keysetWith("disabled-key", KeyStatus.DISABLED));
 
+		assertThatNoException().isThrownBy(() -> store.compromise(definition.getName(), "disabled-key"));
+
+		verify(repository).updateKeyStatus(KeyTransition.compromise(definition.getName(), "disabled-key"));
+		verify(cache).evict(definition.getName());
+	}
+
+	@Test
+	@DisplayName("should throw InvalidKeyStatusTransitionException when compromising a key in an invalid state")
+	void shouldFailToCompromiseKeyInInvalidState() throws IOException {
+		repository.write(keysetWith("pending-key", KeyStatus.PENDING_DESTRUCTION));
+
 		assertThatExceptionOfType(CryptoException.InvalidKeyStatusTransitionException.class)
-			.isThrownBy(() -> store.compromise(definition.getName(), "disabled-key"))
+			.isThrownBy(() -> store.compromise(definition.getName(), "pending-key"))
 			.returns(definition.getName(), CryptoException.KeysetException::getName)
-			.returns("disabled-key", CryptoException.InvalidKeyStatusTransitionException::getKeyId)
-			.returns(KeyStatus.DISABLED, CryptoException.InvalidKeyStatusTransitionException::getCurrentStatus)
+			.returns("pending-key", CryptoException.InvalidKeyStatusTransitionException::getKeyId)
+			.returns(KeyStatus.PENDING_DESTRUCTION, CryptoException.InvalidKeyStatusTransitionException::getCurrentStatus)
 			.returns(KeyStatus.COMPROMISED, CryptoException.InvalidKeyStatusTransitionException::getAttemptedStatus);
 	}
 
@@ -476,6 +487,20 @@ class RepositoryKeysetStoreTest {
 	void shouldRejectBlankNamesOnCompromise() {
 		assertThatIllegalArgumentException().isThrownBy(() -> store.compromise("", "enabled-key"));
 		assertThatIllegalArgumentException().isThrownBy(() -> store.compromise(definition.getName(), ""));
+	}
+
+	@Test
+	@DisplayName("should schedule destruction for a COMPROMISED key at an explicit time")
+	void shouldScheduleDestructionForCompromisedKey() throws IOException {
+		repository.write(keysetWith("compromised-key", KeyStatus.COMPROMISED));
+
+		final Instant destructionTime = Instant.now().plus(Duration.ofDays(30));
+		assertThatNoException().isThrownBy(
+			() -> store.scheduleDestruction(definition.getName(), "compromised-key", destructionTime));
+
+		verify(repository).updateKeyStatus(
+			KeyTransition.scheduleDestruction(definition.getName(), "compromised-key", destructionTime));
+		verify(cache).evict(definition.getName());
 	}
 
 	@Test
@@ -582,14 +607,14 @@ class RepositoryKeysetStoreTest {
 	@Test
 	@DisplayName("should throw InvalidKeyStatusTransitionException for an invalid transition")
 	void shouldFailOnInvalidKeyStatusTransition() throws IOException {
-		repository.write(keysetWith("enabled-key", KeyStatus.ENABLED));
+		repository.write(keysetWith("pending-key", KeyStatus.PENDING_DESTRUCTION));
 
 		assertThatExceptionOfType(CryptoException.InvalidKeyStatusTransitionException.class)
-			.isThrownBy(() -> store.scheduleDestruction(definition.getName(), "enabled-key",
+			.isThrownBy(() -> store.scheduleDestruction(definition.getName(), "pending-key",
 					Instant.now().plusSeconds(60)))
 			.returns(definition.getName(), CryptoException.KeysetException::getName)
-			.returns("enabled-key", CryptoException.InvalidKeyStatusTransitionException::getKeyId)
-			.returns(KeyStatus.ENABLED, CryptoException.InvalidKeyStatusTransitionException::getCurrentStatus)
+			.returns("pending-key", CryptoException.InvalidKeyStatusTransitionException::getKeyId)
+			.returns(KeyStatus.PENDING_DESTRUCTION, CryptoException.InvalidKeyStatusTransitionException::getCurrentStatus)
 			.returns(KeyStatus.PENDING_DESTRUCTION,
 				CryptoException.InvalidKeyStatusTransitionException::getAttemptedStatus);
 	}


### PR DESCRIPTION
Replace the hardcoded expected-status check in `performKeyTransition` with `KeyStatus.canTransitionTo`, which is the single authoritative source for all lifecycle edges. Add `DISABLED→COMPROMISED` and `PENDING_DESTRUCTION→DISABLED` transitions to the state machine, enabling direct compromise of disabled keys and cancellation of scheduled destruction without re-activation.