### PR TITLE
Skip null-data keys in factories and preserve them in JDBC on write

### DIFF
--- a/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
+++ b/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
@@ -339,7 +339,10 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 			}
 		}
 
-		final List<String> toDelete = new ArrayList<>(storedById.keySet());
+		final List<String> toDelete = storedById.values().stream()
+			.filter(key -> key.getData() != null)
+			.map(EncryptedKey::getId)
+			.toList();
 
 		if (log.isDebugEnabled()) {
 			log.debug("Keyset '{}' key diff: {} inserted, {} updated, {} deleted, {} unchanged",

--- a/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
+++ b/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
@@ -303,6 +303,38 @@ class JdbcKeysetRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("should preserve key rows with null data when writing a keyset that no longer includes them")
+	void shouldPreserveNullDataKeyRowsOnWrite() throws IOException {
+		final Instant instant = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+		final Instant destroyedAt = instant.plusSeconds(1);
+
+		final EncryptedKey primaryKey = encryptedKey("primary-key", true, instant, ByteArray.fromString("primary material"));
+		final EncryptedKey oldKey = encryptedKey("old-key", false, instant, ByteArray.fromString("old material"));
+		repository.write(encryptedKeyset("keyset", primaryKey, oldKey));
+
+		repository.updateKeyStatus(KeyTransition.destroy("keyset", "old-key", destroyedAt));
+
+		// Simulate the factory skipping the DESTROYED key: write a keyset containing only the primary key.
+		repository.write(encryptedKeyset("keyset", primaryKey));
+
+		final var stored = repository.read("keyset").orElseThrow();
+
+		assertThat(stored.getKey("old-key"))
+			.isPresent()
+			.hasValueSatisfying(key -> {
+				assertThat(key.getStatus()).isEqualTo(KeyStatus.DESTROYED);
+				assertThat(key.getData()).isNull();
+				assertThat(key.getDestroyedAt()).isEqualTo(destroyedAt);
+			});
+
+		assertThat(stored.getKey("primary-key"))
+			.isPresent()
+			.hasValueSatisfying(key -> assertThat(key.getData()).isNotNull());
+
+		repository.remove("keyset");
+	}
+
+	@Test
 	@DisplayName("should reject table names that are not valid SQL identifiers")
 	void shouldRejectInvalidTableNames() {
 		final var repo = new JdbcKeysetRepository(jdbcOperations, transactionOperations);

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseKeysetFactory.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseKeysetFactory.java
@@ -86,6 +86,10 @@ public class JoseKeysetFactory implements KeysetFactory {
 			.keyEncryptionKey(kek);
 
 		for (EncryptedKey encrypted : encryptedKeyset) {
+			if (encrypted.getData() == null) {
+				continue;
+			}
+
 			final JWK key;
 
 			try {

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseIntegrationTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseIntegrationTest.java
@@ -165,6 +165,34 @@ public class JoseIntegrationTest {
 
 	@Test
 	@Order(6)
+	@DisplayName("should rotate keyset successfully after a key has been destroyed")
+	void shouldRotateAfterKeyDestruction() {
+		final var keyset = store.read(jwsDefinition.getName());
+
+		assertThatObject(keyset).returns(2, Keyset::size);
+
+		final var oldKey = keyset.stream()
+			.filter(key -> !key.isPrimary())
+			.findFirst()
+			.orElseThrow();
+
+		assertThatNoException()
+			.isThrownBy(() -> store.destroy(jwsDefinition.getName(), oldKey.getId()));
+
+		assertThatNoException()
+			.isThrownBy(() -> store.rotate(jwsDefinition.getName()));
+
+		KeysetAssert.assertThat(store.read(jwsDefinition.getName()))
+			.isInstanceOf(JsonWebKeyset.class)
+			.hasSize(2)
+			.assertThatKeys()
+			.filteredOn(Key::isPrimary)
+			.map(Key::getId)
+			.isNotEqualTo(keyset.getPrimary().getId());
+	}
+
+	@Test
+	@Order(7)
 	@DisplayName("should remove keyset from the repository")
 	void shouldRemoveKeyset() {
 		assertThatNoException().isThrownBy(() -> store.remove(jwsDefinition.getName()));

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeysetFactory.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeysetFactory.java
@@ -99,6 +99,10 @@ public class TinkKeysetFactory implements KeysetFactory {
 			.keyEncryptionKey(kek);
 
 		for (EncryptedKey encrypted : encryptedKeyset) {
+			if (encrypted.getData() == null) {
+				continue;
+			}
+
 			final ByteArray unwrapped = kek.unwrap(encrypted.getData());
 			final KeyData data;
 

--- a/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkIntegrationTest.java
+++ b/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkIntegrationTest.java
@@ -142,6 +142,34 @@ public class TinkIntegrationTest {
 
 	@Test
 	@Order(6)
+	@DisplayName("should rotate keyset successfully after a key has been destroyed")
+	void shouldRotateAfterKeyDestruction() {
+		final var keyset = store.read(definition.getName());
+
+		KeysetAssert.assertThat(keyset).hasSize(2);
+
+		final var oldKey = keyset.stream()
+			.filter(key -> !key.isPrimary())
+			.findFirst()
+			.orElseThrow();
+
+		assertThatNoException()
+			.isThrownBy(() -> store.destroy(definition.getName(), oldKey.getId()));
+
+		assertThatNoException()
+			.isThrownBy(() -> store.rotate(definition.getName()));
+
+		KeysetAssert.assertThat(store.read(definition.getName()))
+			.isInstanceOf(TinkKeyset.class)
+			.hasSize(2)
+			.assertThatKeys()
+			.filteredOn(Key::isPrimary)
+			.map(Key::getId)
+			.isNotEqualTo(keyset.getPrimary().getId());
+	}
+
+	@Test
+	@Order(7)
 	@DisplayName("should remove keyset from the repository")
 	void shouldRemoveKeyset() {
 		assertThatNoException().isThrownBy(() -> store.remove(definition.getName()));


### PR DESCRIPTION
- Both `TinkKeysetFactory` and `JoseKeysetFactory` NPEd on DESTROYED-key null data during `create(kek, encryptedKeyset)`, permanently breaking `rotate()` and `read()` for any keyset with a destroyed key. 
- `JdbcKeysetRepository.updateKeys()` treated DESTROYED (null-data) rows as candidates for deletion when the factory-produced keyset omitted them,  wiping the audit trail on the next rotation write.