### PR TITLE
Enable Gradle build cache and configuration cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
 
 apply(plugin = "com.konfigyr.sonatype")
 
+repositories {
+    mavenCentral()
+}
+
 allprojects {
     group = "com.konfigyr"
 	version = "1.0.0-RC7"
@@ -42,7 +46,7 @@ subprojects {
     }
 
     checkstyle {
-        toolVersion = "13.5.0"
+        toolVersion = "13.7.0"
     }
 
 	dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,8 @@
+## Build cache
+org.gradle.caching=true
+
+## Configuration cache
+org.gradle.configuration-cache=true
+
+## Enables parallel subproject execution locally. CI commands still pass --no-parallel which overrides this
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
### Summary

- Enable Gradle build cache (`org.gradle.caching=true`), configuration cache (`org.gradle.configuration-cache=true`), and parallel subproject execution (`org.gradle.parallel=true`) via a new gradle.properties file.
- Upgrade Gradle wrapper from 9.5.1 → 9.6.1 and Checkstyle tool version from 13.5.0 → 13.7.0.

### Why

#### Build cache
Gradle stores task outputs (compiled classes, test results, JaCoCo reports) keyed by their inputs. Unchanged tasks are skipped on subsequent runs. In CI, gradle/actions/setup-gradle automatically backs this cache with GitHub Actions cache, so task outputs are shared across runs on the same branch.

#### Configuration cache
Gradle serializes the resolved task graph after the configuration phase and reuses it on subsequent invocations with unchanged build files. This eliminates the configuration phase overhead entirely on cache hits. Measured on this project: 53 s → 2 s on the second check run (47/47 tasks UP-TO-DATE, configuration cache entry reused).

#### Parallel execution
Enables concurrent subproject execution for local development. CI workflows explicitly pass `--no-parallel`, which takes precedence, so CI behaviour is unchanged.

#### Root-level repositories block
The `checkstyle`, `jacoco`, and `java-library` plugins are declared in the root plugins block because the Kotlin DSL generates type-safe accessors (tasks.test, tasks.jacocoTestReport, checkstyle {}) from that block. Those accessors are used inside subprojects block. Without this, the root project's `:checkstyle` configuration had no repository to resolve `com.puppycrawl.tools:checkstyle` from, causing the configuration cache to fail at serialisation time with "no repositories are defined".
