### PR TITLE
Prepare for the first official release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The easiest way to consume this library is to import the BOM and then declare on
 
 ```kotlin
 dependencies {
-    implementation(platform("com.konfigyr:konfigyr-crypto-dependencies:1.0.0-RC6"))
+    implementation(platform("com.konfigyr:konfigyr-crypto-dependencies:1.0.0"))
 
     // pick the modules you need — versions are managed by the BOM
     implementation("com.konfigyr:konfigyr-crypto-api")
@@ -42,7 +42,7 @@ dependencies {
         <dependency>
             <groupId>com.konfigyr</groupId>
             <artifactId>konfigyr-crypto-dependencies</artifactId>
-            <version>1.0.0-RC6</version>
+            <version>1.0.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,15 +5,13 @@ plugins {
 	id("java-library")
 	id("com.konfigyr.sonatype") apply false
 	id("com.konfigyr.deploy") apply false
-
-    alias(libs.plugins.lombok) apply false
 }
 
 apply(plugin = "com.konfigyr.sonatype")
 
 allprojects {
     group = "com.konfigyr"
-	version = "1.0.0-RC7"
+	version = "1.0.0"
 }
 
 subprojects {
@@ -24,7 +22,6 @@ subprojects {
     apply(plugin = "jacoco")
     apply(plugin = "checkstyle")
     apply(plugin = "java-library")
-    apply(plugin = "io.freefair.lombok")
     apply(plugin = "com.konfigyr.deploy")
 
 	repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,3 @@ spring-starter-jdbc-test = { module = "org.springframework.boot:spring-boot-star
 
 jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version = "10.9.1" }
 tink = { module = "com.google.crypto.tink:tink", version = "1.22.0" }
-
-[plugins]
-lombok = { id = "io.freefair.lombok", version = "9.5.0" }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKey.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKey.java
@@ -1,6 +1,5 @@
 package com.konfigyr.crypto;
 
-import lombok.Getter;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
@@ -18,7 +17,6 @@ import java.util.StringJoiner;
  * @author Vladimir Spasic
  * @since 1.0.0
  */
-@Getter
 @NullMarked
 public abstract class AbstractKey<A extends Algorithm> implements Key {
 
@@ -92,6 +90,51 @@ public abstract class AbstractKey<A extends Algorithm> implements Key {
 		this.expiresAt = builder.expiresAt;
 		this.destructionScheduledAt = builder.destructionScheduledAt;
 		this.destroyedAt = builder.destroyedAt;
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public A getAlgorithm() {
+		return algorithm;
+	}
+
+	@Override
+	public KeyStatus getStatus() {
+		return status;
+	}
+
+	@Override
+	public boolean isPrimary() {
+		return primary;
+	}
+
+	@Override
+	public Instant getCreatedAt() {
+		return createdAt;
+	}
+
+	@Override
+	public @Nullable Instant getInitializedAt() {
+		return initializedAt;
+	}
+
+	@Override
+	public @Nullable Instant getExpiresAt() {
+		return expiresAt;
+	}
+
+	@Override
+	public @Nullable Instant getDestructionScheduledAt() {
+		return destructionScheduledAt;
+	}
+
+	@Override
+	public @Nullable Instant getDestroyedAt() {
+		return destroyedAt;
 	}
 
 	@Override
@@ -202,10 +245,18 @@ public abstract class AbstractKey<A extends Algorithm> implements Key {
 		@Nullable
 		protected Instant destroyedAt;
 
+		/**
+		 * Creates a new builder instance with the creation timestamp set to now.
+		 */
 		protected Builder() {
 			this.createdAt = Instant.now();
 		}
 
+		/**
+		 * Creates a new builder instance pre-populated from the given {@link KeyDefinition}.
+		 *
+		 * @param definition the key definition to copy values from, can't be {@literal null}
+		 */
 		@SuppressWarnings("unchecked")
 		protected Builder(KeyDefinition definition) {
 			this.algorithm = (A) definition.getAlgorithm();
@@ -216,6 +267,11 @@ public abstract class AbstractKey<A extends Algorithm> implements Key {
 				.orElse(null);
 		}
 
+		/**
+		 * Creates a new builder instance pre-populated from an existing {@link Key}.
+		 *
+		 * @param key the existing key to copy values from, can't be {@literal null}
+		 */
 		protected Builder(K key) {
 			this.id = key.id;
 			this.algorithm = key.algorithm;

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKeyset.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/AbstractKeyset.java
@@ -1,6 +1,5 @@
 package com.konfigyr.crypto;
 
-import lombok.Getter;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
@@ -46,7 +45,6 @@ import java.util.*;
  * @see Key
  * @see KeysetFactory
  */
-@Getter
 @NullMarked
 public abstract class AbstractKeyset<T extends Key> implements Keyset {
 
@@ -117,6 +115,36 @@ public abstract class AbstractKeyset<T extends Key> implements Keyset {
 		this.rotationInterval = builder.rotationInterval;
 		this.destructionGracePeriod = builder.destructionGracePeriod;
 		this.version = builder.version;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public long getVersion() {
+		return version;
+	}
+
+	@Override
+	public String getFactory() {
+		return factory;
+	}
+
+	@Override
+	public KeysetPurpose getPurpose() {
+		return purpose;
+	}
+
+	@Override
+	public KeyEncryptionKey getKeyEncryptionKey() {
+		return keyEncryptionKey;
+	}
+
+	@Override
+	public List<T> getKeys() {
+		return keys;
 	}
 
 	@Override
@@ -312,10 +340,18 @@ public abstract class AbstractKeyset<T extends Key> implements Keyset {
 		private long version = 0L;
 		private final List<T> keys;
 
+		/**
+		 * Creates a new empty builder instance.
+		 */
 		protected Builder() {
 			keys = new ArrayList<>();
 		}
 
+		/**
+		 * Creates a new builder instance pre-populated from the given {@link KeysetDefinition}.
+		 *
+		 * @param definition the keyset definition to copy values from, can't be {@literal null}
+		 */
 		protected Builder(KeysetDefinition definition) {
 			name = definition.getName();
 			factory = definition.getAlgorithm().factory();
@@ -325,6 +361,11 @@ public abstract class AbstractKeyset<T extends Key> implements Keyset {
 			keys = new ArrayList<>();
 		}
 
+		/**
+		 * Creates a new builder instance pre-populated from an existing {@link Keyset}.
+		 *
+		 * @param keyset the existing keyset to copy values from, can't be {@literal null}
+		 */
 		protected Builder(K keyset) {
 			name = keyset.getName();
 			factory = keyset.getFactory();
@@ -336,13 +377,18 @@ public abstract class AbstractKeyset<T extends Key> implements Keyset {
 			keys = new ArrayList<>(keyset.size());
 		}
 
+		/**
+		 * Creates a new builder instance pre-populated from an existing {@link EncryptedKeyset}.
+		 *
+		 * @param keyset the encrypted keyset to copy metadata from, can't be {@literal null}
+		 */
 		protected Builder(EncryptedKeyset keyset) {
-			name = keyset.getName();
-			factory = keyset.getFactory();
-			purpose = KeysetPurpose.valueOf(keyset.getPurpose());
-			rotationInterval = keyset.getRotationInterval();
-			destructionGracePeriod = keyset.getDestructionGracePeriod();
-			version = keyset.getVersion();
+			name = keyset.name();
+			factory = keyset.factory();
+			purpose = KeysetPurpose.valueOf(keyset.purpose());
+			rotationInterval = keyset.rotationInterval();
+			destructionGracePeriod = keyset.destructionGracePeriod();
+			version = keyset.version();
 			keys = new ArrayList<>(keyset.size());
 		}
 

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoAutoConfiguration.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoAutoConfiguration.java
@@ -1,7 +1,8 @@
 package com.konfigyr.crypto;
 
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -26,11 +27,18 @@ import org.springframework.context.annotation.Bean;
  * @author Vladimir Spasic
  * @since 1.0.0
  **/
-@Slf4j
 @AutoConfiguration
 @ConditionalOnBean(KeysetFactory.class)
 @ConditionalOnMissingBean(KeysetStore.class)
 public class CryptoAutoConfiguration {
+
+	private static final Logger log = LoggerFactory.getLogger(CryptoAutoConfiguration.class);
+
+	/**
+	 * Creates a new instance of {@link CryptoAutoConfiguration}.
+	 */
+	public CryptoAutoConfiguration() {
+	}
 
 	@Bean
 	@ConditionalOnMissingBean(AlgorithmRegistry.class)

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoException.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/CryptoException.java
@@ -1,6 +1,5 @@
 package com.konfigyr.crypto;
 
-import lombok.Getter;
 import org.jspecify.annotations.NonNull;
 
 import java.io.Serial;
@@ -52,6 +51,9 @@ public abstract class CryptoException extends RuntimeException {
 		@Serial
 		private static final long serialVersionUID = SERIAL;
 
+		/**
+		 * The name of the unknown algorithm.
+		 */
 		private final String algorithmName;
 
 		/**
@@ -66,7 +68,9 @@ public abstract class CryptoException extends RuntimeException {
 		}
 
 		/**
-		 * @return the algorithm name that could not be resolved, never {@literal null}
+		 * Returns the algorithm name that could not be resolved.
+		 *
+		 * @return the algorithm name, never {@literal null}
 		 */
 		public @NonNull String getAlgorithmName() {
 			return algorithmName;
@@ -162,8 +166,9 @@ public abstract class CryptoException extends RuntimeException {
 		}
 
 		/**
-		 * @return name of the {@link KeyEncryptionKeyProvider} for which the exception
-		 * was thrown, never {@literal null}
+		 * Returns the name of the {@link KeyEncryptionKeyProvider} for which the exception was thrown.
+		 *
+		 * @return provider name, never {@literal null}
 		 */
 		public @NonNull String getProvider() {
 			return provider;
@@ -222,8 +227,9 @@ public abstract class CryptoException extends RuntimeException {
 		}
 
 		/**
-		 * @return identifier of the {@link KeyEncryptionKey} for which the exception was
-		 * thrown, never {@literal null}
+		 * Returns the identifier of the {@link KeyEncryptionKey} for which the exception was thrown.
+		 *
+		 * @return key encryption key identifier, never {@literal null}
 		 */
 		public @NonNull String getId() {
 			return this.id;
@@ -285,8 +291,9 @@ public abstract class CryptoException extends RuntimeException {
 		}
 
 		/**
-		 * @return name of the {@link Keyset} for which the exception was thrown, never
-		 * {@literal null}
+		 * Returns the name of the {@link Keyset} for which the exception was thrown.
+		 *
+		 * @return keyset name, never {@literal null}
 		 */
 		public @NonNull String getName() {
 			return name;
@@ -335,7 +342,7 @@ public abstract class CryptoException extends RuntimeException {
 		 * @param encryptedKeyset {@link EncryptedKeyset} for which the exception was thrown, can't be {@literal null}
 		 */
 		public UnsupportedKeysetException(EncryptedKeyset encryptedKeyset) {
-			super(encryptedKeyset.getName(),
+			super(encryptedKeyset.name(),
 					"Could not find any Keyset factory implementation that supports: " + encryptedKeyset
 							+ ". Please register your Keyset factory as a Spring Bean that can unwrap "
 							+ "instances of these Encrypted Keysets.");
@@ -400,8 +407,9 @@ public abstract class CryptoException extends RuntimeException {
 		}
 
 		/**
-		 * @return the {@link KeysetOperation} that was attempted by the {@link Keyset},
-		 * never {@literal null}
+		 * Returns the {@link KeysetOperation} that was attempted upon the {@link Keyset}.
+		 *
+		 * @return the attempted operation, never {@literal null}
 		 */
 		public @NonNull KeysetOperation attemptedOperation() {
 			return attemptedOperation;
@@ -445,8 +453,9 @@ public abstract class CryptoException extends RuntimeException {
 		}
 
 		/**
-		 * @return the {@link KeysetOperation operations} are supported by the
-		 * {@link Keyset}, never {@literal null}
+		 * Returns the {@link KeysetOperation operations} that are supported by the {@link Keyset}.
+		 *
+		 * @return supported operations, never {@literal null}
 		 */
 		public @NonNull Collection<KeysetOperation> supportedOperations() {
 			return supportedOperations;
@@ -516,7 +525,9 @@ public abstract class CryptoException extends RuntimeException {
 		}
 
 		/**
-		 * @return the identifier of the {@link Key} that was not found, never {@literal null}
+		 * Returns the identifier of the {@link Key} that was not found.
+		 *
+		 * @return the key identifier, never {@literal null}
 		 */
 		public @NonNull String getKeyId() {
 			return keyId;
@@ -558,7 +569,7 @@ public abstract class CryptoException extends RuntimeException {
 	 * Call {@code KeysetStore.cancelDestruction} to restore the key to
 	 * {@link KeyStatus#DISABLED} if the destruction was unintended.
 	 */
-	public static class KeysetPendingDestructionException extends KeysetDisabledException {
+	public static class KeysetPendingDestructionException extends KeysetException {
 
 		@Serial
 		private static final long serialVersionUID = SERIAL;
@@ -569,13 +580,8 @@ public abstract class CryptoException extends RuntimeException {
 		 * @param name the name of the {@link Keyset} pending destruction, can't be {@literal null}
 		 */
 		public KeysetPendingDestructionException(String name) {
-			super(name);
-		}
-
-		@Override
-		public String getMessage() {
-			return "Keyset '" + getName() + "' is pending destruction and cannot perform cryptographic "
-					+ "operations. Call cancelDestruction to restore it to a disabled state.";
+			super(name, "Keyset '" + name + "' is pending destruction and cannot perform cryptographic "
+					+ "operations. Call cancelDestruction to restore it to a disabled state.");
 		}
 
 	}
@@ -684,24 +690,28 @@ public abstract class CryptoException extends RuntimeException {
 		}
 
 		/**
-		 * @return the identifier of the {@link Key} for which the transition was attempted,
-		 *         never {@literal null}
+		 * Returns the identifier of the {@link Key} for which the transition was attempted.
+		 *
+		 * @return the key identifier, never {@literal null}
 		 */
 		public @NonNull String getKeyId() {
 			return keyId;
 		}
 
 		/**
-		 * @return the current {@link KeyStatus} of the key when the invalid transition was
-		 *         attempted, never {@literal null}
+		 * Returns the current {@link KeyStatus} of the key when the invalid transition was attempted.
+		 *
+		 * @return the current key status, never {@literal null}
 		 */
 		public @NonNull KeyStatus getCurrentStatus() {
 			return currentStatus;
 		}
 
 		/**
-		 * @return the {@link KeyStatus} that was attempted but is not a valid transition from
-		 *         {@link #getCurrentStatus()}, never {@literal null}
+		 * Returns the {@link KeyStatus} that was attempted but is not a valid transition from
+		 * {@link #getCurrentStatus()}.
+		 *
+		 * @return the attempted key status, never {@literal null}
 		 */
 		public @NonNull KeyStatus getAttemptedStatus() {
 			return attemptedStatus;
@@ -738,7 +748,6 @@ public abstract class CryptoException extends RuntimeException {
 	 * This exception contains both the name of {@link Keyset} and the actual
 	 * {@link KeyEncryptionKey} values for which this exception has been thrown.
 	 */
-	@Getter
 	public static class WrappingException extends KeysetException {
 
 		@Serial
@@ -774,6 +783,15 @@ public abstract class CryptoException extends RuntimeException {
 			this.kek = kek;
 		}
 
+		/**
+		 * Returns the {@link KeyEncryptionKey} that was responsible for the wrapping failure.
+		 *
+		 * @return the key encryption key, never {@literal null}
+		 */
+		public @NonNull KeyEncryptionKey getKek() {
+			return kek;
+		}
+
 	}
 
 	/**
@@ -783,7 +801,6 @@ public abstract class CryptoException extends RuntimeException {
 	 * This exception contains both the name of {@link EncryptedKeyset} and the actual
 	 * {@link KeyEncryptionKey} values for which this exception has been thrown.
 	 */
-	@Getter
 	public static class UnwrappingException extends KeysetException {
 
 		@Serial
@@ -817,6 +834,15 @@ public abstract class CryptoException extends RuntimeException {
 		public UnwrappingException(String key, KeyEncryptionKey kek, String message, Throwable cause) {
 			super(key, message, cause);
 			this.kek = kek;
+		}
+
+		/**
+		 * Returns the {@link KeyEncryptionKey} that was responsible for the unwrapping failure.
+		 *
+		 * @return the key encryption key, never {@literal null}
+		 */
+		public @NonNull KeyEncryptionKey getKek() {
+			return kek;
 		}
 
 	}

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKey.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKey.java
@@ -1,9 +1,6 @@
 package com.konfigyr.crypto;
 
 import com.konfigyr.io.ByteArray;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
@@ -18,84 +15,46 @@ import java.time.Instant;
  * derived from the {@link Key} that is part of the {@link Keyset}
  * <p>
  * Each {@link EncryptedKey} stores the per-key lifecycle metadata alongside the
- * encrypted key material ({@link #getData()}). The metadata fields (status, timestamps)
+ * encrypted key material ({@link #data ()}). The metadata fields (status, timestamps)
  * are stored in plaintext because they are not sensitive; only the cryptographic key
  * bytes are encrypted by the {@link KeyEncryptionKey}.
  * <p>
  * When a key is in {@link KeyStatus#DESTROYED} or {@link KeyStatus#INITIALIZING} state,
- * {@link #getData()} will be {@literal null} because the key material either has not yet
+ * {@link #data ()} will be {@literal null} because the key material either has not yet
  * been generated or has been permanently erased.
  *
+ * @param id                     Unique identifier of this key within the encrypted keyset.
+ * @param algorithm              The name of the {@link Algorithm} that defines the usage, or supported operations, of the encrypted key.
+ * @param type                   Defines the {@link KeyType} of the encrypted key.
+ * @param status                 Returns the status of the encrypted key.
+ * @param primary                Returns {@literal true} if this key is the primary key within the keyset.
+ * @param data                   Wrapped cryptographic key material produced by {@link KeyEncryptionKey#wrap}. Is
+ *                               {@literal null} when the key is in {@link KeyStatus#INITIALIZING} or
+ *                               {@link KeyStatus#DESTROYED} state.
+ * @param createdAt              Timestamp that tells the time when this key was created.
+ * @param initializedAt          Timestamp when cryptographic material was initialized for this key.
+ * @param expiresAt              The time when this key should expire and be rotated.
+ * @param destructionScheduledAt The time when the cryptographic material should be destroyed for this key.
+ * @param destroyedAt            The time when the cryptographic material was destroyed for this key.
  * @author Vladimir Spasic
- * @since 1.0.0
  * @see EncryptedKeyset
  * @see Key
- **/
-@Value
+ * @since 1.0.0
+ */
 @NullMarked
-public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource {
-
-	/**
-	 * Unique identifier of this key within the encrypted keyset.
-	 */
-	String id;
-
-	/**
-	 * The name of the {@link Algorithm} that defines the usage, or supported operations, of the encrypted key.
-	 */
-	String algorithm;
-
-	/**
-	 * Defines the {@link KeyType} of the encrypted key.
-	 */
-	KeyType type;
-
-	/**
-	 * Returns the status of the encrypted key.
-	 */
-	KeyStatus status;
-
-	/**
-	 * Returns {@literal true} if this key is the primary key within the keyset.
-	 */
-	boolean primary;
-
-	/**
-	 * Wrapped cryptographic key material produced by {@link KeyEncryptionKey#wrap}. Is
-	 * {@literal null} when the key is in {@link KeyStatus#INITIALIZING} or
-	 * {@link KeyStatus#DESTROYED} state.
-	 */
-	@Nullable
-	WrappedKeyMaterial data;
-
-	/**
-	 * Timestamp that tells the time when this key was created.
-	 */
-	Instant createdAt;
-
-	/**
-	 * Timestamp when cryptographic material was initialized for this key.
-	 */
-	@Nullable
-	Instant initializedAt;
-
-	/**
-	 * The time when this key should expire and be rotated.
-	 */
-	@Nullable
-	Instant expiresAt;
-
-	/**
-	 * The time when the cryptographic material should be destroyed for this key.
-	 */
-	@Nullable
-	Instant destructionScheduledAt;
-
-	/**
-	 * The time when the cryptographic material was destroyed for this key.
-	 */
-	@Nullable
-	Instant destroyedAt;
+public record EncryptedKey(
+	String id,
+	String algorithm,
+	KeyType type,
+	KeyStatus status,
+	boolean primary,
+	@Nullable WrappedKeyMaterial data,
+	Instant createdAt,
+	@Nullable Instant initializedAt,
+	@Nullable Instant expiresAt,
+	@Nullable Instant destructionScheduledAt,
+	@Nullable Instant destroyedAt
+) implements Comparable<EncryptedKey>, InputStreamSource {
 
 	@Override
 	public InputStream getInputStream() {
@@ -127,23 +86,23 @@ public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource
 	 */
 	public static Builder builder(EncryptedKey existing) {
 		return builder()
-			.id(existing.getId())
-			.algorithm(existing.getAlgorithm())
-			.type(existing.getType())
-			.status(existing.getStatus())
-			.primary(existing.isPrimary())
-			.createdAt(existing.getCreatedAt())
-			.initializedAt(existing.getInitializedAt())
-			.expiresAt(existing.getExpiresAt())
-			.destructionScheduledAt(existing.getDestructionScheduledAt())
-			.destroyedAt(existing.getDestroyedAt());
+			.id(existing.id())
+			.algorithm(existing.algorithm())
+			.type(existing.type())
+			.status(existing.status())
+			.primary(existing.primary())
+			.createdAt(existing.createdAt())
+			.initializedAt(existing.initializedAt())
+			.expiresAt(existing.expiresAt())
+			.destructionScheduledAt(existing.destructionScheduledAt())
+			.destroyedAt(existing.destroyedAt());
 	}
 
 	/**
 	 * Creates a new instance of the {@link EncryptedKey} from the given {@link Key} and wrapped
 	 * key material produced by {@link KeyEncryptionKey#wrap}.
 	 *
-	 * @param key key that is encrypted by the {@link KeyEncryptionKey}, can't be {@literal null}
+	 * @param key  key that is encrypted by the {@link KeyEncryptionKey}, can't be {@literal null}
 	 * @param data wrapped key material, {@literal null} when the key material is not yet initialized
 	 * @return encrypted key, never {@literal  null}
 	 */
@@ -166,8 +125,10 @@ public class EncryptedKey implements Comparable<EncryptedKey>, InputStreamSource
 	 * Builder class used to create new instances of the {@link EncryptedKey}.
 	 */
 	@NullUnmarked
-	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 	public static final class Builder {
+
+		private Builder() {
+		}
 
 		private String id;
 		private String algorithm;

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKeyset.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/EncryptedKeyset.java
@@ -1,9 +1,5 @@
 package com.konfigyr.crypto;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
@@ -27,68 +23,37 @@ import java.util.*;
  * Each individual {@link Key} has its own encrypted material stored as an {@link EncryptedKey},
  * which also carries the per-key lifecycle metadata (status, timestamps).
  *
+ * @param name                   Unique keyset name.
+ * @param purpose                The purpose of the key material in this keyset, stored as the enum name.
+ * @param factory                The name of the {@link KeysetFactory} that manages this keyset.
+ * @param provider               {@link KeyEncryptionKeyProvider} name that supplied the {@link KeyEncryptionKey} to encrypt this keyset.
+ * @param keyEncryptionKey       The identifier of the {@link KeyEncryptionKey} used to wrap and unwrap this keyset.
+ * @param keys                   Per-key encrypted material with lifecycle metadata.
+ * @param rotationInterval       Rotation frequency for the keyset. {@literal null} when automatic rotation is disabled.
+ * @param destructionGracePeriod Grace period between scheduling key destruction and the actual removal of key material.
+ *                               {@literal null} when the destruction grace period is disabled.
+ * @param version                Optimistic-locking version counter. Zero for keysets not yet persisted; incremented
+ *                               by the {@link KeysetRepository} on every successful write operation.
+ *                               <p>
+ *                               Excluded from equality checks: two {@link EncryptedKeyset}s with identical cryptographic
+ *                               content but different persistence versions are considered equal.
  * @author Vladimir Spasic
- * @since 1.0.0
  * @see KeysetFactory
  * @see KeysetRepository
- **/
-@Value
+ * @since 1.0.0
+ */
 @NullMarked
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class EncryptedKeyset implements Iterable<EncryptedKey> {
-
-	/**
-	 * Unique keyset name.
-	 */
-	String name;
-
-	/**
-	 * The purpose of the key material in this keyset, stored as the enum name.
-	 */
-	String purpose;
-
-	/**
-	 * The name of the {@link KeysetFactory} that manages this keyset.
-	 */
-	String factory;
-
-	/**
-	 * {@link KeyEncryptionKeyProvider} name that supplied the {@link KeyEncryptionKey} to encrypt this keyset.
-	 */
-	String provider;
-
-	/**
-	 * The identifier of the {@link KeyEncryptionKey} used to wrap and unwrap this keyset.
-	 */
-	String keyEncryptionKey;
-
-	/**
-	 * Per-key encrypted material with lifecycle metadata.
-	 */
-	List<EncryptedKey> keys;
-
-	/**
-	 * Rotation frequency for the keyset. {@literal null} when automatic rotation is disabled.
-	 */
-	@Nullable
-	Duration rotationInterval;
-
-	/**
-	 * Grace period between scheduling key destruction and the actual removal of key material.
-	 * {@literal null} when the destruction grace period is disabled.
-	 */
-	@Nullable
-	Duration destructionGracePeriod;
-
-	/**
-	 * Optimistic-locking version counter. Zero for keysets not yet persisted; incremented
-	 * by the {@link KeysetRepository} on every successful write operation.
-	 * <p>
-	 * Excluded from equality checks: two {@link EncryptedKeyset}s with identical cryptographic
-	 * content but different persistence versions are considered equal.
-	 */
-	@EqualsAndHashCode.Exclude
-	long version;
+public record EncryptedKeyset(
+	String name,
+	String purpose,
+	String factory,
+	String provider,
+	String keyEncryptionKey,
+	List<EncryptedKey> keys,
+	@Nullable Duration rotationInterval,
+	@Nullable Duration destructionGracePeriod,
+	long version
+) implements Iterable<EncryptedKey> {
 
 	/**
 	 * Attempts to find the {@link EncryptedKey} with the given identifier.
@@ -98,7 +63,7 @@ public class EncryptedKeyset implements Iterable<EncryptedKey> {
 	 */
 	public Optional<EncryptedKey> getKey(String id) {
 		return keys.stream()
-			.filter(key -> Objects.equals(key.getId(), id))
+			.filter(key -> Objects.equals(key.id(), id))
 			.findFirst();
 	}
 
@@ -116,8 +81,28 @@ public class EncryptedKeyset implements Iterable<EncryptedKey> {
 		return keys.iterator();
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof EncryptedKeyset that)) return false;
+		return Objects.equals(name, that.name)
+			&& Objects.equals(purpose, that.purpose)
+			&& Objects.equals(factory, that.factory)
+			&& Objects.equals(provider, that.provider)
+			&& Objects.equals(keyEncryptionKey, that.keyEncryptionKey)
+			&& Objects.equals(keys, that.keys)
+			&& Objects.equals(rotationInterval, that.rotationInterval)
+			&& Objects.equals(destructionGracePeriod, that.destructionGracePeriod);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, purpose, factory, provider, keyEncryptionKey, keys,
+			rotationInterval, destructionGracePeriod);
+	}
+
 	/**
-	 * Creates a new empty instance of the {@link EncryptedKeyset.Builder}.
+	 * Creates a new empty instance of the {@link Builder}.
+	 *
 	 * @return encrypted keyset builder, never {@literal  null}
 	 */
 	public static Builder builder() {
@@ -125,7 +110,7 @@ public class EncryptedKeyset implements Iterable<EncryptedKey> {
 	}
 
 	/**
-	 * Creates a new instance of the {@link EncryptedKeyset.Builder} populated from the given
+	 * Creates a new instance of the {@link Builder} populated from the given
 	 * {@link KeysetDefinition}.
 	 *
 	 * @param definition definition from which the builder would be populated, can't be {@literal null}
@@ -141,7 +126,7 @@ public class EncryptedKeyset implements Iterable<EncryptedKey> {
 	}
 
 	/**
-	 * Creates a new instance of the {@link EncryptedKeyset.Builder} pre-populated from an existing
+	 * Creates a new instance of the {@link Builder} pre-populated from an existing
 	 * {@link EncryptedKeyset}. All metadata fields are copied; the key list is left empty and must
 	 * be provided via {@link Builder#build(List)} or {@link Builder#build(EncryptedKey...)}.
 	 * <p>
@@ -153,14 +138,14 @@ public class EncryptedKeyset implements Iterable<EncryptedKey> {
 	 */
 	public static Builder builder(EncryptedKeyset existing) {
 		return builder()
-			.name(existing.getName())
-			.purpose(KeysetPurpose.valueOf(existing.getPurpose()))
-			.factory(existing.getFactory())
-			.provider(existing.getProvider())
-			.keyEncryptionKey(existing.getKeyEncryptionKey())
-			.rotationInterval(existing.getRotationInterval())
-			.destructionGracePeriod(existing.getDestructionGracePeriod())
-			.version(existing.getVersion());
+			.name(existing.name())
+			.purpose(KeysetPurpose.valueOf(existing.purpose()))
+			.factory(existing.factory())
+			.provider(existing.provider())
+			.keyEncryptionKey(existing.keyEncryptionKey())
+			.rotationInterval(existing.rotationInterval())
+			.destructionGracePeriod(existing.destructionGracePeriod())
+			.version(existing.version());
 	}
 
 	/**
@@ -168,7 +153,7 @@ public class EncryptedKeyset implements Iterable<EncryptedKey> {
 	 * {@link EncryptedKey encrypted keys}.
 	 *
 	 * @param keyset keyset that is encrypted by the {@link KeyEncryptionKey}, can't be {@literal null}
-	 * @param keys per-key encrypted material, can't be {@literal null}
+	 * @param keys   per-key encrypted material, can't be {@literal null}
 	 * @return encrypted keyset, never {@literal  null}
 	 */
 	public static EncryptedKeyset from(Keyset keyset, List<EncryptedKey> keys) {
@@ -189,8 +174,10 @@ public class EncryptedKeyset implements Iterable<EncryptedKey> {
 	 * Builder class used to create new instances of the {@link EncryptedKeyset}.
 	 */
 	@NullUnmarked
-	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 	public static final class Builder {
+
+		private Builder() {
+		}
 
 		private String name;
 		private String purpose;

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/InMemoryKeysetRepository.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/InMemoryKeysetRepository.java
@@ -21,6 +21,12 @@ public class InMemoryKeysetRepository implements KeysetRepository {
 
 	private final Map<String, EncryptedKeyset> store = new ConcurrentHashMap<>();
 
+	/**
+	 * Creates a new empty in-memory keyset repository.
+	 */
+	public InMemoryKeysetRepository() {
+	}
+
 	@Override
 	public Optional<EncryptedKeyset> read(String name) {
 		return Optional.ofNullable(store.get(name));
@@ -28,14 +34,14 @@ public class InMemoryKeysetRepository implements KeysetRepository {
 
 	@Override
 	public EncryptedKeyset write(EncryptedKeyset keyset) {
-		return store.compute(keyset.getName(), (name, existing) -> {
-			if (existing != null && existing.getVersion() != keyset.getVersion()) {
+		return store.compute(keyset.name(), (name, existing) -> {
+			if (existing != null && existing.version() != keyset.version()) {
 				throw new CryptoException.KeysetConcurrentModificationException(name);
 			}
 
 			return EncryptedKeyset.builder(keyset)
-				.version(existing == null ? 0L : keyset.getVersion() + 1)
-				.build(keyset.getKeys());
+				.version(existing == null ? 0L : keyset.version() + 1)
+				.build(keyset.keys());
 		});
 	}
 
@@ -57,10 +63,10 @@ public class InMemoryKeysetRepository implements KeysetRepository {
 		final List<EncryptedKeyset> result = new ArrayList<>();
 		for (EncryptedKeyset keyset : store.values()) {
 			final List<EncryptedKey> pending = new ArrayList<>();
-			for (EncryptedKey key : keyset.getKeys()) {
-				if (key.getStatus() == KeyStatus.PENDING_DESTRUCTION
-						&& key.getDestructionScheduledAt() != null
-						&& !key.getDestructionScheduledAt().isAfter(now)) {
+			for (EncryptedKey key : keyset.keys()) {
+				if (key.status() == KeyStatus.PENDING_DESTRUCTION
+						&& key.destructionScheduledAt() != null
+						&& !key.destructionScheduledAt().isAfter(now)) {
 					pending.add(key);
 				}
 			}
@@ -76,16 +82,16 @@ public class InMemoryKeysetRepository implements KeysetRepository {
 	 * <p>
 	 * Scans all stored keysets and returns metadata-only {@link EncryptedKeyset} views (empty
 	 * key list) for keysets whose primary {@link KeyStatus#ENABLED} key's
-	 * {@link EncryptedKey#getExpiresAt() expiry time} is in the past.
+	 * {@link EncryptedKey#expiresAt() expiry time} is in the past.
 	 */
 	@Override
 	public List<EncryptedKeyset> findPendingRotation() {
 		final Instant now = Instant.now();
 		final List<EncryptedKeyset> result = new ArrayList<>();
 		for (EncryptedKeyset keyset : store.values()) {
-			for (EncryptedKey key : keyset.getKeys()) {
-				if (key.getStatus() == KeyStatus.ENABLED && key.isPrimary()) {
-					if (key.getExpiresAt() != null && !key.getExpiresAt().isAfter(now)) {
+			for (EncryptedKey key : keyset.keys()) {
+				if (key.status() == KeyStatus.ENABLED && key.primary()) {
+					if (key.expiresAt() != null && !key.expiresAt().isAfter(now)) {
 						result.add(EncryptedKeyset.builder(keyset).build(List.of()));
 					}
 					break;

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyDefinition.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyDefinition.java
@@ -97,10 +97,25 @@ public interface KeyDefinition {
 	 */
 	class Builder {
 
+		/**
+		 * Whether the new key should become the primary key in the keyset. Defaults to {@literal true}.
+		 */
 		protected boolean primary = true;
+
+		/**
+		 * The {@link Algorithm} to use when generating the new key material. Must not be {@literal null}.
+		 */
 		protected @Nullable Algorithm algorithm;
+
+		/**
+		 * The duration after which the new key expires and becomes eligible for rotation.
+		 * {@literal null} disables automatic expiry.
+		 */
 		protected @Nullable Duration rotationInterval;
 
+		/**
+		 * Creates a new builder with default values: primary key, no fixed rotation interval.
+		 */
 		protected Builder() {
 		}
 

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyEncryptionKeyProvider.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyEncryptionKeyProvider.java
@@ -61,7 +61,7 @@ public interface KeyEncryptionKeyProvider {
 	 * not resolve the {@link KeyEncryptionKey} with the given identifier
 	 */
 	default KeyEncryptionKey provide(EncryptedKeyset encryptedKeyset) {
-		return provide(encryptedKeyset.getKeyEncryptionKey());
+		return provide(encryptedKeyset.keyEncryptionKey());
 	}
 
 	/**

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyTransition.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeyTransition.java
@@ -1,8 +1,5 @@
 package com.konfigyr.crypto;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -13,8 +10,8 @@ import java.time.Instant;
  * {@link KeysetRepository}.
  * <p>
  * A {@code KeyTransition} carries the keyset name, key identifier, target {@link KeyStatus},
- * and the two optional timestamps ({@link #getDestructionScheduledAt() destructionScheduledAt}
- * and {@link #getDestroyedAt() destroyedAt}) that are set or cleared as part of the transition.
+ * and the two optional timestamps ({@link #destructionScheduledAt () destructionScheduledAt}
+ * and {@link #destroyedAt () destroyedAt}) that are set or cleared as part of the transition.
  * <p>
  * Instances must be created through one of the static factory methods. Each factory encodes
  * the semantics of exactly one state-machine edge and ensures that only the timestamp fields
@@ -38,65 +35,44 @@ import java.time.Instant;
  * KeyTransition.destroy(encryptedKeyset, keyId, Instant.now());
  * }</pre>
  *
+ * @param keysetName             The name of the keyset that contains the key being transitioned.
+ * @param keyId                  The identifier of the key version being transitioned.
+ * @param status                 The target {@link KeyStatus} to assign to the key version.
+ * @param destructionScheduledAt The time at which the key is scheduled for destruction. Populated when transitioning
+ *                               to {@link KeyStatus#PENDING_DESTRUCTION}; {@code null} for all other transitions.
+ * @param destroyedAt            The time at which the key material was permanently erased. Populated when transitioning
+ *                               to {@link KeyStatus#DESTROYED}; {@code null} for all other transitions.
+ * @param keysetVersion          The expected {@link EncryptedKeyset#version() keyset version} against which the
+ *                               repository should guard when applying this transition.
+ *                               <p>
+ *                               Implementations of {@link KeysetRepository} that apply transitions should reject
+ *                               the update when the stored version no longer matches this value and throw
+ *                               {@link CryptoException.KeysetConcurrentModificationException}.
  * @author Vladimir Spasic
- * @since 1.0.0
  * @see KeysetRepository#updateKeyStatus(KeyTransition)
  * @see KeysetStore
- **/
-@Value
+ * @since 1.0.0
+ */
 @NullMarked
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class KeyTransition {
-
-	/**
-	 * The name of the keyset that contains the key being transitioned.
-	 */
-	String keysetName;
-
-	/**
-	 * The identifier of the key version being transitioned.
-	 */
-	String keyId;
-
-	/**
-	 * The target {@link KeyStatus} to assign to the key version.
-	 */
-	KeyStatus status;
-
-	/**
-	 * The time at which the key is scheduled for destruction. Populated when transitioning
-	 * to {@link KeyStatus#PENDING_DESTRUCTION}; {@code null} for all other transitions.
-	 */
-	@Nullable
-	Instant destructionScheduledAt;
-
-	/**
-	 * The time at which the key material was permanently erased. Populated when transitioning
-	 * to {@link KeyStatus#DESTROYED}; {@code null} for all other transitions.
-	 */
-	@Nullable
-	Instant destroyedAt;
-
-	/**
-	 * The expected {@link EncryptedKeyset#getVersion() keyset version} against which the
-	 * repository should guard when applying this transition.
-	 * <p>
-	 * Implementations of {@link KeysetRepository} that apply transitions should reject
-	 * the update when the stored version no longer matches this value and throw
-	 * {@link CryptoException.KeysetConcurrentModificationException}.
-	 */
-	long keysetVersion;
+public record KeyTransition(
+	String keysetName,
+	String keyId,
+	KeyStatus status,
+	@Nullable Instant destructionScheduledAt,
+	@Nullable Instant destroyedAt,
+	long keysetVersion
+) {
 
 	/**
 	 * Creates a transition that moves a key from {@link KeyStatus#ENABLED} to
 	 * {@link KeyStatus#DISABLED}.
 	 *
 	 * @param keyset the keyset containing the key, can't be {@literal null}
-	 * @param keyId the identifier of the key to disable, can't be {@literal null}
+	 * @param keyId  the identifier of the key to disable, can't be {@literal null}
 	 * @return the transition, never {@literal null}
 	 */
 	public static KeyTransition disable(EncryptedKeyset keyset, String keyId) {
-		return new KeyTransition(keyset.getName(), keyId, KeyStatus.DISABLED, null, null, keyset.getVersion());
+		return new KeyTransition(keyset.name(), keyId, KeyStatus.DISABLED, null, null, keyset.version());
 	}
 
 	/**
@@ -104,11 +80,11 @@ public class KeyTransition {
 	 * {@link KeyStatus#ENABLED}.
 	 *
 	 * @param keyset the keyset containing the key, can't be {@literal null}
-	 * @param keyId the identifier of the key to re-enable, can't be {@literal null}
+	 * @param keyId  the identifier of the key to re-enable, can't be {@literal null}
 	 * @return the transition, never {@literal null}
 	 */
 	public static KeyTransition enable(EncryptedKeyset keyset, String keyId) {
-		return new KeyTransition(keyset.getName(), keyId, KeyStatus.ENABLED, null, null, keyset.getVersion());
+		return new KeyTransition(keyset.name(), keyId, KeyStatus.ENABLED, null, null, keyset.version());
 	}
 
 	/**
@@ -120,27 +96,27 @@ public class KeyTransition {
 	 * for destruction via {@link KeysetStore#scheduleDestruction(String, String)}.
 	 *
 	 * @param keyset the keyset containing the key, can't be {@literal null}
-	 * @param keyId the identifier of the key to mark as compromised, can't be {@literal null}
+	 * @param keyId  the identifier of the key to mark as compromised, can't be {@literal null}
 	 * @return the transition, never {@literal null}
 	 */
 	public static KeyTransition compromise(EncryptedKeyset keyset, String keyId) {
-		return new KeyTransition(keyset.getName(), keyId, KeyStatus.COMPROMISED, null, null, keyset.getVersion());
+		return new KeyTransition(keyset.name(), keyId, KeyStatus.COMPROMISED, null, null, keyset.version());
 	}
 
 	/**
 	 * Creates a transition that moves a key from {@link KeyStatus#DISABLED} to
 	 * {@link KeyStatus#PENDING_DESTRUCTION}, recording the scheduled destruction time.
 	 *
-	 * @param keyset the keyset containing the key, can't be {@literal null}
-	 * @param keyId the identifier of the key to schedule for destruction, can't be {@literal null}
+	 * @param keyset                 the keyset containing the key, can't be {@literal null}
+	 * @param keyId                  the identifier of the key to schedule for destruction, can't be {@literal null}
 	 * @param destructionScheduledAt the time at which the key should be destroyed,
 	 *                               can't be {@literal null}
 	 * @return the transition, never {@literal null}
 	 */
 	public static KeyTransition scheduleDestruction(
-			EncryptedKeyset keyset, String keyId, Instant destructionScheduledAt) {
-		return new KeyTransition(keyset.getName(), keyId, KeyStatus.PENDING_DESTRUCTION,
-				destructionScheduledAt, null, keyset.getVersion());
+		EncryptedKeyset keyset, String keyId, Instant destructionScheduledAt) {
+		return new KeyTransition(keyset.name(), keyId, KeyStatus.PENDING_DESTRUCTION,
+			destructionScheduledAt, null, keyset.version());
 	}
 
 	/**
@@ -148,29 +124,29 @@ public class KeyTransition {
 	 * {@link KeyStatus#DISABLED}, clearing the previously scheduled destruction time.
 	 *
 	 * @param keyset the keyset containing the key, can't be {@literal null}
-	 * @param keyId the identifier of the key whose destruction should be canceled,
-	 *              can't be {@literal null}
+	 * @param keyId  the identifier of the key whose destruction should be canceled,
+	 *               can't be {@literal null}
 	 * @return the transition, never {@literal null}
 	 */
 	public static KeyTransition cancelDestruction(EncryptedKeyset keyset, String keyId) {
-		return new KeyTransition(keyset.getName(), keyId, KeyStatus.DISABLED, null, null, keyset.getVersion());
+		return new KeyTransition(keyset.name(), keyId, KeyStatus.DISABLED, null, null, keyset.version());
 	}
 
 	/**
 	 * Creates a transition that moves a key from {@link KeyStatus#PENDING_DESTRUCTION} to
 	 * {@link KeyStatus#DESTROYED}.
 	 * <p>
-	 * The key material ({@link EncryptedKey#getData()}) is erased — set to {@code null} — by
+	 * The key material ({@link EncryptedKey#data()}) is erased — set to {@code null} — by
 	 * the repository when this transition is applied. The row itself is kept for audit purposes.
 	 *
-	 * @param keyset the keyset containing the key, can't be {@literal null}
-	 * @param keyId the identifier of the key to destroy, can't be {@literal null}
+	 * @param keyset      the keyset containing the key, can't be {@literal null}
+	 * @param keyId       the identifier of the key to destroy, can't be {@literal null}
 	 * @param destroyedAt the instant at which the key material was erased, can't be
 	 *                    {@literal null}
 	 * @return the transition, never {@literal null}
 	 */
 	public static KeyTransition destroy(EncryptedKeyset keyset, String keyId, Instant destroyedAt) {
-		return new KeyTransition(keyset.getName(), keyId, KeyStatus.DESTROYED, null, destroyedAt, keyset.getVersion());
+		return new KeyTransition(keyset.name(), keyId, KeyStatus.DESTROYED, null, destroyedAt, keyset.version());
 	}
 
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetDefinition.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetDefinition.java
@@ -195,21 +195,43 @@ public interface KeysetDefinition {
 	 */
 	class Builder {
 
+		/**
+		 * Unique name that identifies the {@link Keyset} within the {@link KeysetStore}. Must not be blank.
+		 */
 		@Nullable
 		protected String name;
 
+		/**
+		 * The cryptographic purpose that determines which operations the {@link Keyset} supports.
+		 * Derived from {@link #algorithm} when not set explicitly.
+		 */
 		@Nullable
 		protected KeysetPurpose purpose;
 
+		/**
+		 * The {@link Algorithm} used to generate key material and perform cryptographic operations.
+		 * Must not be {@literal null}.
+		 */
 		@Nullable
 		protected Algorithm algorithm;
 
+		/**
+		 * How often key material should be automatically rotated. Defaults to 90 days.
+		 * {@literal null} disables automatic rotation.
+		 */
 		@Nullable
 		protected Duration rotationInterval = Duration.ofDays(90);
 
+		/**
+		 * Safety window between a deletion request and permanent key destruction. Defaults to 30 days.
+		 * {@literal null} disables the grace period.
+		 */
 		@Nullable
 		protected Duration destructionGracePeriod = Duration.ofDays(30);
 
+		/**
+		 * Creates a new builder with default values: 90-day rotation interval and 30-day destruction grace period.
+		 */
 		protected Builder() {
 		}
 
@@ -325,6 +347,12 @@ public interface KeysetDefinition {
 			return this;
 		}
 
+		/**
+		 * Builds the {@link KeysetDefinition} from the current builder state.
+		 *
+		 * @return keyset definition, never {@literal null}
+		 * @throws IllegalArgumentException when required fields are missing or intervals are out of range
+		 */
 		public KeysetDefinition build() {
 			Assert.hasText(name, "Keyset name can not be blank");
 			Assert.notNull(algorithm, "Keyset algorithm can not be null");

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetFactory.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetFactory.java
@@ -51,7 +51,7 @@ public interface KeysetFactory {
 	 * @return <code>true</code> if the factory can attempt keyset decryption
 	 */
 	default boolean supports(EncryptedKeyset encryptedKeyset) {
-		return Objects.equals(getName(), encryptedKeyset.getFactory());
+		return Objects.equals(getName(), encryptedKeyset.factory());
 	}
 
 	/**

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetRepository.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetRepository.java
@@ -32,7 +32,7 @@ public interface KeysetRepository {
 	 * Writes the data of the {@link EncryptedKeyset} to the repository and returns the
 	 * persisted form with a version that reflects the committed state.
 	 * <p>
-	 * Implementations should use the {@link EncryptedKeyset#getVersion() keyset version} for
+	 * Implementations should use the {@link EncryptedKeyset#version() keyset version} for
 	 * optimistic locking: persist only when the stored version matches the version on the
 	 * incoming keyset, and return the keyset with the version advanced to the newly committed
 	 * value. If a concurrent modification is detected, throw
@@ -63,11 +63,11 @@ public interface KeysetRepository {
 	 * <p>
 	 * When the transition targets {@link KeyStatus#DESTROYED}, implementations
 	 * <strong>must</strong> erase the encrypted key material
-	 * ({@link EncryptedKey#getData()} becomes {@literal null}).
+	 * ({@link EncryptedKey#data()} becomes {@literal null}).
 	 * The row itself is kept for audit purposes.
 	 * <p>
 	 * Implementations that apply the transition via a targeted SQL {@code UPDATE} (rather than
-	 * a full read-modify-write cycle) should use {@link KeyTransition#getKeysetVersion()} as an
+	 * a full read-modify-write cycle) should use {@link KeyTransition#keysetVersion()} as an
 	 * optimistic-locking guard: bump {@code KEYSET_VERSION} only when the stored version matches
 	 * the transition's version, and throw
 	 * {@link CryptoException.KeysetConcurrentModificationException} when no rows are affected.
@@ -75,7 +75,7 @@ public interface KeysetRepository {
 	 * The default implementation uses a read-modify-write cycle via {@link #read(String)} and
 	 * {@link #write(EncryptedKeyset)}, which inherits version checking from {@link #write}.
 	 * <p>
-	 * If no keyset exists under {@link KeyTransition#getKeysetName()}, this method returns
+	 * If no keyset exists under {@link KeyTransition#keysetName()}, this method returns
 	 * silently without error.
 	 *
 	 * @param transition the lifecycle transition to apply, can't be {@literal null}
@@ -84,19 +84,19 @@ public interface KeysetRepository {
 	 * @throws IOException if there is an issue while updating the key status
 	 */
 	default void updateKeyStatus(KeyTransition transition) throws IOException {
-		final Optional<EncryptedKeyset> existing = read(transition.getKeysetName());
+		final Optional<EncryptedKeyset> existing = read(transition.keysetName());
 		if (existing.isEmpty()) {
 			return;
 		}
 		final EncryptedKeyset keyset = existing.get();
 		final List<EncryptedKey> updatedKeys = new ArrayList<>(keyset.size());
 		for (EncryptedKey key : keyset) {
-			if (key.getId().equals(transition.getKeyId())) {
-				final WrappedKeyMaterial data = transition.getStatus() == KeyStatus.DESTROYED ? null : key.getData();
+			if (key.id().equals(transition.keyId())) {
+				final WrappedKeyMaterial data = transition.status() == KeyStatus.DESTROYED ? null : key.data();
 				updatedKeys.add(EncryptedKey.builder(key)
-					.status(transition.getStatus())
-					.destructionScheduledAt(transition.getDestructionScheduledAt())
-					.destroyedAt(transition.getDestroyedAt())
+					.status(transition.status())
+					.destructionScheduledAt(transition.destructionScheduledAt())
+					.destroyedAt(transition.destroyedAt())
 					.build(data));
 			} else {
 				updatedKeys.add(key);
@@ -109,7 +109,7 @@ public interface KeysetRepository {
 	 * Returns a list of partial {@link EncryptedKeyset} objects where each contains only
 	 * the {@link EncryptedKey keys} whose {@link KeyStatus} is
 	 * {@link KeyStatus#PENDING_DESTRUCTION} and whose
-	 * {@link EncryptedKey#getDestructionScheduledAt() scheduled destruction time} is in the
+	 * {@link EncryptedKey#destructionScheduledAt() scheduled destruction time} is in the
 	 * past (i.e., the grace period has elapsed).
 	 * <p>
 	 * Each returned {@link EncryptedKeyset} is a <em>partial view</em> — it carries the
@@ -139,7 +139,7 @@ public interface KeysetRepository {
 	/**
 	 * Returns a list of partial {@link EncryptedKeyset} objects for keysets whose rotation
 	 * interval has elapsed. A keyset is eligible for rotation when its primary
-	 * {@link KeyStatus#ENABLED} key's {@link EncryptedKey#getExpiresAt() expiry time} is in
+	 * {@link KeyStatus#ENABLED} key's {@link EncryptedKey#expiresAt() expiry time} is in
 	 * the past, i.e.:
 	 * <pre>
 	 *     primaryKey.expiresAt &lt;= now

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetStore.java
@@ -1,8 +1,9 @@
 package com.konfigyr.crypto;
 
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cache.support.NoOpCache;
 import org.springframework.util.Assert;
 
@@ -73,10 +74,10 @@ public interface KeysetStore {
 	/**
 	 * Creates a new {@link Builder} instance that can be used to create {@link KeysetStore} instances.
 	 * <p>
-	 * This builder would return an instance of {@link RepostoryKeysetStore} by default.
+	 * This builder would return an instance of {@link RepositoryKeysetStore} by default.
 	 *
 	 * @return the keyset store builder, never {@literal null}.
-	 * @see RepostoryKeysetStore
+	 * @see RepositoryKeysetStore
 	 */
 	static Builder builder() {
 		return new Builder();
@@ -359,7 +360,7 @@ public interface KeysetStore {
 	 * Permanently destroys the specified {@link Key} within the named {@link Keyset} by erasing
 	 * its encrypted key material and transitioning it to {@link KeyStatus#DESTROYED}.
 	 * <p>
-	 * The key row is retained for audit purposes but its {@link EncryptedKey#getData() data} is
+	 * The key row is retained for audit purposes but its {@link EncryptedKey#data() data} is
 	 * set to {@literal null} and can never be recovered. This is a soft-delete of the key material.
 	 * <p>
 	 * Requires the key to be in {@link KeyStatus#PENDING_DESTRUCTION} state. To destroy without
@@ -376,10 +377,11 @@ public interface KeysetStore {
 
 	/**
 	 * Builder class used to create {@link KeysetStore} instances. This builder would return an instance of
-	 * {@link RepostoryKeysetStore} by default.
+	 * {@link RepositoryKeysetStore} by default.
 	 */
-	@Slf4j
 	final class Builder {
+		private final Logger log = LoggerFactory.getLogger(KeysetStore.Builder.class);
+
 		private @Nullable KeysetCache cache;
 		private @Nullable KeysetRepository repository;
 		private final List<KeysetFactory> factories;
@@ -478,7 +480,7 @@ public interface KeysetStore {
 				cache = new SpringKeysetCache(new NoOpCache("noop-keyset-cache"));
 			}
 
-			return new RepostoryKeysetStore(cache, repository, factories, providers);
+			return new RepositoryKeysetStore(cache, repository, factories, providers);
 		}
 	}
 

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetTaskAutoConfiguration.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetTaskAutoConfiguration.java
@@ -1,8 +1,7 @@
 package com.konfigyr.crypto;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -22,7 +21,7 @@ import java.util.List;
  * Two maintenance tasks are registered by default:
  * <ul>
  *     <li><em>keyset-rotation</em> — calls {@link KeysetStore#rotate(String)} for every
- *     keyset whose primary key's {@link EncryptedKey#getExpiresAt() expiry time} has
+ *     keyset whose primary key's {@link EncryptedKey#expiresAt() expiry time} has
  *     elapsed. Controlled via {@code konfigyr.crypto.tasks.keyset-rotation.*}.</li>
  *     <li><em>keyset-destruction</em> — calls
  *     {@link KeysetStore#destroy(String, String)} for every key whose
@@ -49,7 +48,6 @@ import java.util.List;
  * @since 1.0.0
  * @see KeysetTaskRegistration
  **/
-@RequiredArgsConstructor
 @EnableScheduling
 @AutoConfiguration
 @AutoConfigureAfter(CryptoAutoConfiguration.class)
@@ -59,6 +57,12 @@ public class KeysetTaskAutoConfiguration {
 	private final Environment environment;
 	private final KeysetStore keysetStore;
 	private final KeysetRepository keysetRepository;
+
+	KeysetTaskAutoConfiguration(Environment environment, KeysetStore keysetStore, KeysetRepository keysetRepository) {
+		this.environment = environment;
+		this.keysetStore = keysetStore;
+		this.keysetRepository = keysetRepository;
+	}
 
 	/**
 	 * Registers the keyset rotation task, which queries for keysets whose primary key's
@@ -90,12 +94,17 @@ public class KeysetTaskAutoConfiguration {
 	 * elapsed. Failures for individual keysets are caught and logged so that one failure
 	 * does not prevent the remaining keysets from being rotated.
 	 */
-	@Slf4j
-	@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 	static final class KeysetRotationTask implements Runnable {
+
+		private static final Logger log = LoggerFactory.getLogger(KeysetRotationTask.class);
 
 		private final KeysetStore store;
 		private final KeysetRepository repository;
+
+		KeysetRotationTask(KeysetStore store, KeysetRepository repository) {
+			this.store = store;
+			this.repository = repository;
+		}
 
 		@Override
 		public void run() {
@@ -115,10 +124,10 @@ public class KeysetTaskAutoConfiguration {
 
 			for (EncryptedKeyset keyset : pending) {
 				try {
-					log.debug("Rotating keyset '{}'", keyset.getName());
-					store.rotate(keyset.getName());
+					log.debug("Rotating keyset '{}'", keyset.name());
+					store.rotate(keyset.name());
 				} catch (Exception e) {
-					log.error("Failed to rotate keyset '{}'", keyset.getName(), e);
+					log.error("Failed to rotate keyset '{}'", keyset.name(), e);
 				}
 			}
 		}
@@ -131,12 +140,17 @@ public class KeysetTaskAutoConfiguration {
 	 * elapsed. Failures for individual keys are caught and logged so that one failure
 	 * does not prevent the remaining keys from being destroyed.
 	 */
-	@Slf4j
-	@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 	static final class KeysetDestructionTask implements Runnable {
+
+		private static final Logger log = LoggerFactory.getLogger(KeysetDestructionTask.class);
 
 		private final KeysetStore store;
 		private final KeysetRepository repository;
+
+		KeysetDestructionTask(KeysetStore store, KeysetRepository repository) {
+			this.store = store;
+			this.repository = repository;
+		}
 
 		@Override
 		public void run() {
@@ -157,10 +171,10 @@ public class KeysetTaskAutoConfiguration {
 			for (EncryptedKeyset keyset : pending) {
 				for (EncryptedKey key : keyset) {
 					try {
-						log.debug("Destroying key '{}' in keyset '{}'", key.getId(), keyset.getName());
-						store.destroy(keyset.getName(), key.getId());
+						log.debug("Destroying key '{}' in keyset '{}'", key.id(), keyset.name());
+						store.destroy(keyset.name(), key.id());
 					} catch (Exception e) {
-						log.error("Failed to destroy key '{}' in keyset '{}'", key.getId(), keyset.getName(), e);
+						log.error("Failed to destroy key '{}' in keyset '{}'", key.id(), keyset.name(), e);
 					}
 				}
 			}

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetTaskRegistration.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/KeysetTaskRegistration.java
@@ -1,10 +1,9 @@
 package com.konfigyr.crypto;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
@@ -34,16 +33,20 @@ import java.time.Duration;
  * @since 1.0.0
  * @see KeysetTaskAutoConfiguration
  **/
-@Slf4j
 @NullMarked
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 final class KeysetTaskRegistration implements SchedulingConfigurer {
 
 	static final ConfigurationPropertyName PREFIX = ConfigurationPropertyName.of("konfigyr.crypto.tasks");
 
 	static final TriggerProperties DEFAULT_PROPERTIES = new TriggerProperties(null, Duration.ofHours(1), true);
 
+	private static final Logger log = LoggerFactory.getLogger(KeysetTaskRegistration.class);
+
 	private final TriggerTask task;
+
+	private KeysetTaskRegistration(TriggerTask task) {
+		this.task = task;
+	}
 
 	/**
 	 * Creates a {@link KeysetTaskRegistration} for the given task name by constructing a

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepositoryKeysetStore.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/RepositoryKeysetStore.java
@@ -32,7 +32,7 @@ import static com.konfigyr.crypto.CryptoException.*;
  * @since 1.0.0
  **/
 @NullMarked
-public class RepostoryKeysetStore implements KeysetStore {
+public class RepositoryKeysetStore implements KeysetStore {
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -45,14 +45,14 @@ public class RepostoryKeysetStore implements KeysetStore {
 	private final List<KeyEncryptionKeyProvider> providers;
 
 	/**
-	 * Creates a new {@link RepostoryKeysetStore} instance using the provided arguments.
+	 * Creates a new {@link RepositoryKeysetStore} instance using the provided arguments.
 	 *
 	 * @param cache the keyset cache implementation, can't be {@literal null}
 	 * @param repository the keyset repository implementation, can't be {@literal null}
 	 * @param factories the list of keyset factories, can't be {@literal null}
 	 * @param providers the list of key encryption key providers, can't be {@literal null}
 	 */
-	public RepostoryKeysetStore(
+	public RepositoryKeysetStore(
 		KeysetCache cache,
 		KeysetRepository repository,
 		List<KeysetFactory> factories,
@@ -187,7 +187,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 		Assert.hasText(keyId, "Key ID must not be blank");
 
 		performKeyTransition(keysetName, keyset -> {
-			final Duration gracePeriod = keyset.getDestructionGracePeriod();
+			final Duration gracePeriod = keyset.destructionGracePeriod();
 
 			if (gracePeriod != null) {
 				return KeyTransition.scheduleDestruction(keyset, keyId, Instant.now().plus(gracePeriod));
@@ -230,20 +230,20 @@ public class RepostoryKeysetStore implements KeysetStore {
 	private void performKeyTransition(String keysetName, Function<EncryptedKeyset, KeyTransition> transitionFactory) {
 		final EncryptedKeyset encryptedKeyset = lookupKeyset(keysetName);
 		final KeyTransition transition = transitionFactory.apply(encryptedKeyset);
-		final String keyId = transition.getKeyId();
+		final String keyId = transition.keyId();
 
 		final EncryptedKey key = encryptedKeyset.getKey(keyId).orElseThrow(
 			() -> new KeyNotFoundException(keysetName, keyId)
 		);
 
-		if (!key.getStatus().canTransitionTo(transition.getStatus())) {
-			throw new InvalidKeyStatusTransitionException(keysetName, keyId, key.getStatus(),
-				transition.getStatus());
+		if (!key.status().canTransitionTo(transition.status())) {
+			throw new InvalidKeyStatusTransitionException(keysetName, keyId, key.status(),
+				transition.status());
 		}
 
 		if (logger.isDebugEnabled()) {
 			logger.debug("Transitioning key '{}' in keyset '{}' from {} to {}", keyId, keysetName,
-				key.getStatus(), transition.getStatus());
+				key.status(), transition.status());
 		}
 
 		try {
@@ -364,11 +364,11 @@ public class RepostoryKeysetStore implements KeysetStore {
 	 */
 	protected Keyset read(KeysetFactory factory, EncryptedKeyset encryptedKeyset) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("Reading encrypted keyset data with name: {}", encryptedKeyset.getName());
+			logger.debug("Reading encrypted keyset data with name: {}", encryptedKeyset.name());
 		}
 
-		final KeyEncryptionKeyProvider provider = provider(encryptedKeyset.getProvider())
-			.orElseThrow(() -> new ProviderNotFoundException(encryptedKeyset.getProvider()));
+		final KeyEncryptionKeyProvider provider = provider(encryptedKeyset.provider())
+			.orElseThrow(() -> new ProviderNotFoundException(encryptedKeyset.provider()));
 
 		final KeyEncryptionKey kek = provider.provide(encryptedKeyset);
 
@@ -376,7 +376,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 			return factory.create(kek, encryptedKeyset);
 		}
 		catch (IOException e) {
-			throw new UnwrappingException(encryptedKeyset.getName(), kek, e);
+			throw new UnwrappingException(encryptedKeyset.name(), kek, e);
 		}
 	}
 
@@ -410,7 +410,7 @@ public class RepostoryKeysetStore implements KeysetStore {
 					"Could not write encrypted keyset with name: " + keyset.getName(), e);
 		}
 
-		cache.put(written.getName(), written);
+		cache.put(written.name(), written);
 	}
 
 	/**

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SimpleAlgorithmRegistry.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SimpleAlgorithmRegistry.java
@@ -31,6 +31,12 @@ public class SimpleAlgorithmRegistry implements AlgorithmRegistry, SmartInitiali
 
 	private volatile boolean sealed = false;
 
+	/**
+	 * Creates a new empty algorithm registry.
+	 */
+	public SimpleAlgorithmRegistry() {
+	}
+
 	@Override
 	public void afterSingletonsInstantiated() {
 		sealed = true;

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SimpleKeyDefinition.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SimpleKeyDefinition.java
@@ -1,12 +1,12 @@
 package com.konfigyr.crypto;
 
-import lombok.Value;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -17,23 +17,59 @@ import java.util.Optional;
  * @since 1.0.0
  * @see KeyDefinition
  **/
-@Value
 @NullMarked
-class SimpleKeyDefinition implements KeyDefinition, Serializable {
+final class SimpleKeyDefinition implements KeyDefinition, Serializable {
 
 	@Serial
 	private static final long serialVersionUID = -6184743082416027679L;
 
-	Algorithm algorithm;
+	private final Algorithm algorithm;
 
-	boolean primary;
+	private final boolean primary;
 
 	@Nullable
-	Duration rotationInterval;
+	private final Duration rotationInterval;
+
+	SimpleKeyDefinition(Algorithm algorithm, boolean primary, @Nullable Duration rotationInterval) {
+		this.algorithm = algorithm;
+		this.primary = primary;
+		this.rotationInterval = rotationInterval;
+	}
+
+	@Override
+	public Algorithm getAlgorithm() {
+		return algorithm;
+	}
+
+	@Override
+	public boolean isPrimary() {
+		return primary;
+	}
 
 	@Override
 	public Optional<@Nullable Duration> getRotationInterval() {
 		return Optional.ofNullable(rotationInterval);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof SimpleKeyDefinition that)) return false;
+		return primary == that.primary
+			&& Objects.equals(algorithm, that.algorithm)
+			&& Objects.equals(rotationInterval, that.rotationInterval);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(algorithm, primary, rotationInterval);
+	}
+
+	@Override
+	public String toString() {
+		return "SimpleKeyDefinition[algorithm=" + algorithm
+			+ ", primary=" + primary
+			+ ", rotationInterval=" + rotationInterval + "]";
 	}
 
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SimpleKeysetDefinition.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SimpleKeysetDefinition.java
@@ -1,12 +1,12 @@
 package com.konfigyr.crypto;
 
-import lombok.Value;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -17,24 +17,47 @@ import java.util.Optional;
  * @since 1.0.0
  * @see KeysetFactory#create(KeyEncryptionKey, KeysetDefinition)
  **/
-@Value
 @NullMarked
-class SimpleKeysetDefinition implements KeysetDefinition, Serializable {
+final class SimpleKeysetDefinition implements KeysetDefinition, Serializable {
 
 	@Serial
 	private static final long serialVersionUID = 283753676517870624L;
 
-	String name;
+	private final String name;
 
-	KeysetPurpose purpose;
+	private final KeysetPurpose purpose;
 
-	Algorithm algorithm;
-
-	@Nullable
-	Duration rotationInterval;
+	private final Algorithm algorithm;
 
 	@Nullable
-	Duration destructionGracePeriod;
+	private final Duration rotationInterval;
+
+	@Nullable
+	private final Duration destructionGracePeriod;
+
+	SimpleKeysetDefinition(String name, KeysetPurpose purpose, Algorithm algorithm,
+			@Nullable Duration rotationInterval, @Nullable Duration destructionGracePeriod) {
+		this.name = name;
+		this.purpose = purpose;
+		this.algorithm = algorithm;
+		this.rotationInterval = rotationInterval;
+		this.destructionGracePeriod = destructionGracePeriod;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public KeysetPurpose getPurpose() {
+		return purpose;
+	}
+
+	@Override
+	public Algorithm getAlgorithm() {
+		return algorithm;
+	}
 
 	@Override
 	public Optional<@Nullable Duration> getRotationInterval() {
@@ -44,6 +67,31 @@ class SimpleKeysetDefinition implements KeysetDefinition, Serializable {
 	@Override
 	public Optional<@Nullable Duration> getDestructionGracePeriod() {
 		return Optional.ofNullable(destructionGracePeriod);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof SimpleKeysetDefinition that)) return false;
+		return Objects.equals(name, that.name)
+			&& Objects.equals(purpose, that.purpose)
+			&& Objects.equals(algorithm, that.algorithm)
+			&& Objects.equals(rotationInterval, that.rotationInterval)
+			&& Objects.equals(destructionGracePeriod, that.destructionGracePeriod);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, purpose, algorithm, rotationInterval, destructionGracePeriod);
+	}
+
+	@Override
+	public String toString() {
+		return "SimpleKeysetDefinition[name=" + name
+			+ ", purpose=" + purpose
+			+ ", algorithm=" + algorithm
+			+ ", rotationInterval=" + rotationInterval
+			+ ", destructionGracePeriod=" + destructionGracePeriod + "]";
 	}
 
 }

--- a/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SpringKeysetCache.java
+++ b/konfigyr-crypto-api/src/main/java/com/konfigyr/crypto/SpringKeysetCache.java
@@ -1,6 +1,5 @@
 package com.konfigyr.crypto;
 
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.cache.Cache;
@@ -15,10 +14,18 @@ import java.util.function.Supplier;
  * @since 1.0.0
  **/
 @NullMarked
-@RequiredArgsConstructor
 public class SpringKeysetCache implements KeysetCache {
 
 	private final Cache cache;
+
+	/**
+	 * Creates a new {@link SpringKeysetCache} backed by the given Spring {@link Cache}.
+	 *
+	 * @param cache the backing Spring cache, can't be {@literal null}
+	 */
+	public SpringKeysetCache(Cache cache) {
+		this.cache = cache;
+	}
 
 	@Override
 	public synchronized EncryptedKeyset get(String key, Supplier<@Nullable EncryptedKeyset> supplier) {

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/CryptoAutoConfigurationTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/CryptoAutoConfigurationTest.java
@@ -41,7 +41,7 @@ class CryptoAutoConfigurationTest {
 		new ApplicationContextRunner().withConfiguration(configurations).run(ctx -> assertThat(ctx)
 			.hasNotFailed()
 			.doesNotHaveBean(CryptoAutoConfiguration.class)
-			.doesNotHaveBean(RepostoryKeysetStore.class)
+			.doesNotHaveBean(RepositoryKeysetStore.class)
 			.doesNotHaveBean(InMemoryKeysetRepository.class)
 		);
 	}
@@ -54,7 +54,7 @@ class CryptoAutoConfigurationTest {
 		runner.withBean(KeysetStore.class, () -> store).run(ctx -> assertThat(ctx)
 			.hasNotFailed()
 			.doesNotHaveBean(CryptoAutoConfiguration.class)
-			.doesNotHaveBean(RepostoryKeysetStore.class)
+			.doesNotHaveBean(RepositoryKeysetStore.class)
 			.doesNotHaveBean(InMemoryKeysetRepository.class)
 			.getBean(KeysetStore.class)
 			.isEqualTo(store)
@@ -79,7 +79,7 @@ class CryptoAutoConfigurationTest {
 		runner.withBean(KeyEncryptionKeyProvider.class, () -> provider).run(ctx -> assertThat(ctx)
 			.hasNotFailed()
 			.hasSingleBean(CryptoAutoConfiguration.class)
-			.hasSingleBean(RepostoryKeysetStore.class)
+			.hasSingleBean(RepositoryKeysetStore.class)
 			.hasSingleBean(InMemoryKeysetRepository.class)
 		);
 	}
@@ -94,7 +94,7 @@ class CryptoAutoConfigurationTest {
 			.run(ctx -> assertThat(ctx)
 				.hasNotFailed()
 				.hasSingleBean(CryptoAutoConfiguration.class)
-				.hasSingleBean(RepostoryKeysetStore.class)
+				.hasSingleBean(RepositoryKeysetStore.class)
 				.doesNotHaveBean(InMemoryKeysetRepository.class)
 				.getBean(KeysetRepository.class)
 				.isEqualTo(repository)

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeyTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeyTest.java
@@ -64,7 +64,7 @@ class EncryptedKeyTest {
 			.destroyedAt(null)
 			.build(data);
 
-		final var copy = EncryptedKey.builder(original).build(original.getData());
+		final var copy = EncryptedKey.builder(original).build(original.data());
 
 		assertThat(copy).isEqualTo(original);
 	}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeysetTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/EncryptedKeysetTest.java
@@ -72,7 +72,7 @@ class EncryptedKeysetTest {
 			.destructionGracePeriod(Duration.ofDays(30))
 			.build(List.of(key));
 
-		final var copy = EncryptedKeyset.builder(original).build(original.getKeys());
+		final var copy = EncryptedKeyset.builder(original).build(original.keys());
 
 		assertThat(copy).isEqualTo(original);
 	}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/InMemoryKeysetRepositoryTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/InMemoryKeysetRepositoryTest.java
@@ -26,13 +26,13 @@ class InMemoryKeysetRepositoryTest {
 		final EncryptedKeyset keyset = encryptedKeyset("test-keyset",
 			encryptedKey("key-1", KeyStatus.ENABLED, true, ByteArray.fromString("key-material"), null));
 
-		assertThat(repository.read(keyset.getName())).isEmpty();
+		assertThat(repository.read(keyset.name())).isEmpty();
 
 		assertThatNoException().isThrownBy(() -> repository.write(keyset));
-		assertThat(repository.read(keyset.getName())).hasValue(keyset);
+		assertThat(repository.read(keyset.name())).hasValue(keyset);
 
-		assertThatNoException().isThrownBy(() -> repository.remove(keyset.getName()));
-		assertThat(repository.read(keyset.getName())).isEmpty();
+		assertThatNoException().isThrownBy(() -> repository.remove(keyset.name()));
+		assertThat(repository.read(keyset.name())).isEmpty();
 	}
 
 	@Test
@@ -51,8 +51,8 @@ class InMemoryKeysetRepositoryTest {
 				assertThat(ks.getKey("key-1"))
 					.isPresent()
 					.hasValueSatisfying(k -> {
-						assertThat(k.getStatus()).isEqualTo(KeyStatus.DISABLED);
-						assertThat(k.getData()).isNotNull();
+						assertThat(k.status()).isEqualTo(KeyStatus.DISABLED);
+						assertThat(k.data()).isNotNull();
 					})
 			);
 	}
@@ -75,9 +75,9 @@ class InMemoryKeysetRepositoryTest {
 				assertThat(ks.getKey("key-1"))
 					.isPresent()
 					.hasValueSatisfying(k -> {
-						assertThat(k.getStatus()).isEqualTo(KeyStatus.DESTROYED);
-						assertThat(k.getData()).isNull();
-						assertThat(k.getDestroyedAt()).isEqualTo(destroyedAt);
+						assertThat(k.status()).isEqualTo(KeyStatus.DESTROYED);
+						assertThat(k.data()).isNull();
+						assertThat(k.destroyedAt()).isEqualTo(destroyedAt);
 					})
 			);
 	}
@@ -99,8 +99,8 @@ class InMemoryKeysetRepositoryTest {
 				assertThat(ks.getKey("key-1"))
 					.isPresent()
 					.hasValueSatisfying(k -> {
-						assertThat(k.getStatus()).isEqualTo(KeyStatus.PENDING_DESTRUCTION);
-						assertThat(k.getDestructionScheduledAt()).isEqualTo(scheduledAt);
+						assertThat(k.status()).isEqualTo(KeyStatus.PENDING_DESTRUCTION);
+						assertThat(k.destructionScheduledAt()).isEqualTo(scheduledAt);
 					})
 			);
 	}
@@ -116,9 +116,9 @@ class InMemoryKeysetRepositoryTest {
 		final List<EncryptedKeyset> results = repository.findPendingDestruction();
 
 		assertThat(results).hasSize(1);
-		assertThat(results.getFirst().getName()).isEqualTo("test-keyset");
-		assertThat(results.getFirst().getKeys()).hasSize(1);
-		assertThat(results.getFirst().getKeys().getFirst().getId()).isEqualTo("key-1");
+		assertThat(results.getFirst().name()).isEqualTo("test-keyset");
+		assertThat(results.getFirst().keys()).hasSize(1);
+		assertThat(results.getFirst().keys().getFirst().id()).isEqualTo("key-1");
 	}
 
 	@Test
@@ -169,8 +169,8 @@ class InMemoryKeysetRepositoryTest {
 		assertThat(results)
 			.hasSize(1)
 			.first()
-			.returns("due-for-rotation", EncryptedKeyset::getName)
-			.extracting(EncryptedKeyset::getKeys)
+			.returns("due-for-rotation", EncryptedKeyset::name)
+			.extracting(EncryptedKeyset::keys)
 			.isEqualTo(List.of());
 	}
 
@@ -189,7 +189,7 @@ class InMemoryKeysetRepositoryTest {
 		repository.write(encryptedKeyset("not-due", freshKey));
 
 		assertThat(repository.findPendingRotation())
-			.extracting(EncryptedKeyset::getName)
+			.extracting(EncryptedKeyset::name)
 			.doesNotContain("not-due");
 	}
 
@@ -213,7 +213,7 @@ class InMemoryKeysetRepositoryTest {
 		repository.write(keyset);
 
 		assertThat(repository.findPendingRotation())
-			.extracting(EncryptedKeyset::getName)
+			.extracting(EncryptedKeyset::name)
 			.doesNotContain("no-expiry");
 	}
 

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/KeysetStoreBuilderTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/KeysetStoreBuilderTest.java
@@ -34,7 +34,7 @@ class KeysetStoreBuilderTest {
 
 		assertThat(store)
 			.isNotNull()
-			.isInstanceOf(RepostoryKeysetStore.class);
+			.isInstanceOf(RepositoryKeysetStore.class);
 
 		assertThat(store)
 			.extracting("cache")
@@ -59,7 +59,7 @@ class KeysetStoreBuilderTest {
 
 		assertThat(store)
 			.isNotNull()
-			.isInstanceOf(RepostoryKeysetStore.class);
+			.isInstanceOf(RepositoryKeysetStore.class);
 
 		assertThat(store)
 			.extracting("cache")

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepositoryKeysetStoreTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepositoryKeysetStoreTest.java
@@ -706,6 +706,81 @@ class RepositoryKeysetStoreTest {
 		assertThatIllegalArgumentException().isThrownBy(() -> store.destroy(definition.getName(), ""));
 	}
 
+	@Test
+	@DisplayName("should rotate the keyset by name with a key definition and persist the result")
+	void shouldRotateKeysetByNameWithDefinition() throws IOException {
+		final var rotated = mock(Keyset.class);
+		final var rotatedEncryptedKeyset = mock(EncryptedKeyset.class);
+		final var keyDefinition = KeyDefinition.of(TestAlgorithm.INSTANCE);
+
+		doReturn(true).when(factory).supports(any(EncryptedKeyset.class));
+		doReturn(keyset).when(factory).create(kek, encryptedKeyset);
+		doReturn(KeysetPurpose.ENCRYPTION).when(keyset).getPurpose();
+		doReturn(FACTORY_NAME).when(factory).getName();
+		doReturn(FACTORY_NAME).when(keyset).getFactory();
+		doReturn(rotated).when(keyset).rotate(keyDefinition);
+		doReturn(rotatedEncryptedKeyset).when(factory).create(rotated);
+		doReturn(definition.getName()).when(rotatedEncryptedKeyset).name();
+		doReturn(rotatedEncryptedKeyset).when(repository).write(rotatedEncryptedKeyset);
+
+		repository.write(encryptedKeyset);
+
+		assertThatNoException().isThrownBy(() -> store.rotate(definition.getName(), keyDefinition));
+
+		verify(keyset).rotate(keyDefinition);
+		verify(factory).create(rotated);
+		verify(repository).write(rotatedEncryptedKeyset);
+		verify(cache).put(definition.getName(), rotatedEncryptedKeyset);
+	}
+
+	@Test
+	@DisplayName("should rotate the keyset by reference with a key definition and persist the result")
+	void shouldRotateKeysetWithDefinition() throws IOException {
+		final var rotated = mock(Keyset.class);
+		final var keyDefinition = KeyDefinition.of(TestAlgorithm.INSTANCE);
+
+		doReturn(KeysetPurpose.ENCRYPTION).when(keyset).getPurpose();
+		doReturn(FACTORY_NAME).when(factory).getName();
+		doReturn(FACTORY_NAME).when(keyset).getFactory();
+		doReturn(rotated).when(keyset).rotate(keyDefinition);
+		doReturn(encryptedKeyset).when(factory).create(rotated);
+
+		assertThatNoException().isThrownBy(() -> store.rotate(keyset, keyDefinition));
+
+		verify(keyset).rotate(keyDefinition);
+		verify(factory).create(rotated);
+		verify(repository).write(encryptedKeyset);
+		verify(cache).put(definition.getName(), encryptedKeyset);
+	}
+
+	@Test
+	@DisplayName("should throw UnsupportedAlgorithmException when key definition algorithm purpose does not match keyset purpose")
+	void shouldFailToRotateWhenAlgorithmPurposeMismatch() {
+		final var keyDefinition = KeyDefinition.of(TestAlgorithm.INSTANCE); // ENCRYPTION purpose
+
+		doReturn(KeysetPurpose.SIGNING).when(keyset).getPurpose(); // mismatch
+
+		assertThatExceptionOfType(CryptoException.UnsupportedAlgorithmException.class)
+			.isThrownBy(() -> store.rotate(keyset, keyDefinition))
+			.returns(TestAlgorithm.INSTANCE, CryptoException.UnsupportedAlgorithmException::getAlgorithm);
+
+		verifyNoInteractions(repository);
+	}
+
+	@Test
+	@DisplayName("should throw KeysetException when repository raises an IOException during key status update")
+	void shouldFailToUpdateKeyStatusOnIOException() throws IOException {
+		final var cause = new IOException("db error");
+
+		repository.write(keysetWith("enabled-key", KeyStatus.ENABLED));
+		doThrow(cause).when(repository).updateKeyStatus(any());
+
+		assertThatExceptionOfType(CryptoException.KeysetException.class)
+			.isThrownBy(() -> store.disable(definition.getName(), "enabled-key"))
+			.withCause(cause)
+			.returns(definition.getName(), CryptoException.KeysetException::getName);
+	}
+
 	private EncryptedKeyset keysetWith(String keyId, KeyStatus status) {
 		return EncryptedKeyset.builder(definition)
 			.provider(kek.getProvider())

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepositoryKeysetStoreTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/RepositoryKeysetStoreTest.java
@@ -148,7 +148,7 @@ class RepositoryKeysetStoreTest {
 		doReturn(true).when(factory).supports(encryptedKeyset);
 		doReturn(keyset).when(factory).create(kek, encryptedKeyset);
 
-		cache.put(encryptedKeyset.getName(), encryptedKeyset);
+		cache.put(encryptedKeyset.name(), encryptedKeyset);
 
 		assertThat(store.read(definition.getName())).isEqualTo(keyset);
 
@@ -184,7 +184,7 @@ class RepositoryKeysetStoreTest {
 		doReturn(true).when(factory).supports(any(EncryptedKeyset.class));
 		doReturn(keyset).when(factory).create(kek, encryptedKeyset);
 		doReturn(rotatedEncryptedKeyset).when(factory).create(rotated);
-		doReturn(definition.getName()).when(rotatedEncryptedKeyset).getName();
+		doReturn(definition.getName()).when(rotatedEncryptedKeyset).name();
 		doReturn(rotatedEncryptedKeyset).when(repository).write(rotatedEncryptedKeyset);
 
 		repository.write(encryptedKeyset);
@@ -286,7 +286,7 @@ class RepositoryKeysetStoreTest {
 		doThrow(IOException.class).when(factory).create(kek, definition);
 
 		assertThatExceptionOfType(CryptoException.KeysetException.class)
-			.isThrownBy(() -> store.create(encryptedKeyset.getProvider(), encryptedKeyset.getKeyEncryptionKey(), definition))
+			.isThrownBy(() -> store.create(encryptedKeyset.provider(), encryptedKeyset.keyEncryptionKey(), definition))
 			.returns(definition.getName(), CryptoException.KeysetException::getName)
 			.withCauseInstanceOf(IOException.class);
 
@@ -533,11 +533,11 @@ class RepositoryKeysetStoreTest {
 			() -> store.scheduleDestruction(definition.getName(), "disabled-key"));
 
 		verify(repository).updateKeyStatus(assertArg(t -> {
-			assertThat(t.getKeysetName()).isEqualTo(definition.getName());
-			assertThat(t.getKeyId()).isEqualTo("disabled-key");
-			assertThat(t.getStatus()).isEqualTo(KeyStatus.PENDING_DESTRUCTION);
-			assertThat(t.getDestructionScheduledAt()).isNotNull();
-			assertThat(t.getDestroyedAt()).isNull();
+			assertThat(t.keysetName()).isEqualTo(definition.getName());
+			assertThat(t.keyId()).isEqualTo("disabled-key");
+			assertThat(t.status()).isEqualTo(KeyStatus.PENDING_DESTRUCTION);
+			assertThat(t.destructionScheduledAt()).isNotNull();
+			assertThat(t.destroyedAt()).isNull();
 		}));
 		verify(cache).evict(definition.getName());
 	}
@@ -558,11 +558,11 @@ class RepositoryKeysetStoreTest {
 			() -> store.scheduleDestruction(definition.getName(), "disabled-key"));
 
 		verify(repository).updateKeyStatus(assertArg(t -> {
-			assertThat(t.getKeysetName()).isEqualTo(definition.getName());
-			assertThat(t.getKeyId()).isEqualTo("disabled-key");
-			assertThat(t.getStatus()).isEqualTo(KeyStatus.DESTROYED);
-			assertThat(t.getDestructionScheduledAt()).isNull();
-			assertThat(t.getDestroyedAt()).isNotNull();
+			assertThat(t.keysetName()).isEqualTo(definition.getName());
+			assertThat(t.keyId()).isEqualTo("disabled-key");
+			assertThat(t.status()).isEqualTo(KeyStatus.DESTROYED);
+			assertThat(t.destructionScheduledAt()).isNull();
+			assertThat(t.destroyedAt()).isNotNull();
 		}));
 	}
 
@@ -586,10 +586,10 @@ class RepositoryKeysetStoreTest {
 		assertThatNoException().isThrownBy(() -> store.destroy(definition.getName(), "pending-key"));
 
 		verify(repository).updateKeyStatus(assertArg(t -> {
-			assertThat(t.getKeysetName()).isEqualTo(definition.getName());
-			assertThat(t.getKeyId()).isEqualTo("pending-key");
-			assertThat(t.getStatus()).isEqualTo(KeyStatus.DESTROYED);
-			assertThat(t.getDestroyedAt()).isNotNull();
+			assertThat(t.keysetName()).isEqualTo(definition.getName());
+			assertThat(t.keyId()).isEqualTo("pending-key");
+			assertThat(t.status()).isEqualTo(KeyStatus.DESTROYED);
+			assertThat(t.destroyedAt()).isNotNull();
 		}));
 		verify(cache).evict(definition.getName());
 	}

--- a/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/SpringKeysetCacheTest.java
+++ b/konfigyr-crypto-api/src/test/java/com/konfigyr/crypto/SpringKeysetCacheTest.java
@@ -40,11 +40,11 @@ class SpringKeysetCacheTest {
 		final var keyset = createEncryptedKeyset("test-keyset");
 		doReturn(keyset).when(supplier).get();
 
-		assertThat(cache.get(keyset.getName(), supplier)).isEqualTo(keyset);
-		assertThat(cache.get(keyset.getName(), supplier)).isEqualTo(keyset);
+		assertThat(cache.get(keyset.name(), supplier)).isEqualTo(keyset);
+		assertThat(cache.get(keyset.name(), supplier)).isEqualTo(keyset);
 
 		verify(supplier).get();
-		verify(delegate, times(2)).get(eq(keyset.getName()), eq(EncryptedKeyset.class));
+		verify(delegate, times(2)).get(eq(keyset.name()), eq(EncryptedKeyset.class));
 	}
 
 	@Test

--- a/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetAutoConfiguration.java
+++ b/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetAutoConfiguration.java
@@ -2,7 +2,6 @@ package com.konfigyr.crypto.jdbc;
 
 import com.konfigyr.crypto.CryptoAutoConfiguration;
 import com.konfigyr.crypto.KeysetRepository;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -35,7 +34,6 @@ import javax.sql.DataSource;
  * @author Vladimir Spasic
  * @since 1.0.0
  **/
-@RequiredArgsConstructor
 @AutoConfiguration
 @AutoConfigureAfter({ DataSourceAutoConfiguration.class, TransactionAutoConfiguration.class })
 @AutoConfigureBefore(CryptoAutoConfiguration.class)
@@ -46,13 +44,22 @@ public class JdbcKeysetAutoConfiguration {
 
 	private final JdbcKeysetProperties properties;
 
+	/**
+	 * Creates a new {@link JdbcKeysetAutoConfiguration} instance.
+	 *
+	 * @param properties the JDBC keyset configuration properties, can't be {@literal null}
+	 */
+	public JdbcKeysetAutoConfiguration(JdbcKeysetProperties properties) {
+		this.properties = properties;
+	}
+
 	@Bean
 	KeysetRepository jdbcKeysetRepository(DataSource dataSource, PlatformTransactionManager txManager) {
 		final JdbcKeysetRepository repository = new JdbcKeysetRepository(createJdbcOperations(dataSource),
 				createTransactionOperations(txManager, properties));
 
-		repository.setTableName(properties.getTableName());
-		repository.setKeysTableName(properties.getKeysTableName());
+		repository.setTableName(properties.tableName());
+		repository.setKeysTableName(properties.keysTableName());
 
 		return repository;
 	}
@@ -77,9 +84,9 @@ public class JdbcKeysetAutoConfiguration {
 		@NonNull JdbcKeysetProperties properties
 	) {
 		final TransactionTemplate template = new TransactionTemplate(txManager);
-		template.setPropagationBehavior(properties.getTransactionPropagationBehavior().value());
-		template.setIsolationLevel(properties.getTransactionIsolationLevel().value());
-		template.setTimeout((int) properties.getTransactionTimeout().toSeconds());
+		template.setPropagationBehavior(properties.transactionPropagationBehavior().value());
+		template.setIsolationLevel(properties.transactionIsolationLevel().value());
+		template.setTimeout((int) properties.transactionTimeout().toSeconds());
 		template.setName("jdbc-keyset-repository-transaction-operations");
 		template.setReadOnly(false);
 		template.afterPropertiesSet();

--- a/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetDataSourceScriptDatabaseInitializer.java
+++ b/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetDataSourceScriptDatabaseInitializer.java
@@ -10,7 +10,7 @@ import javax.sql.DataSource;
 import java.util.List;
 
 /**
- * {@link DataSourceScriptDatabaseInitializer} for the Konfigyr Keyseet JDBC database. May
+ * {@link DataSourceScriptDatabaseInitializer} for the Konfigyr Keyset JDBC database. May
  * be registered as a bean to override autoconfiguration.
  *
  * @author Vladimir Spasic
@@ -30,17 +30,17 @@ public class JdbcKeysetDataSourceScriptDatabaseInitializer extends DataSourceScr
 	}
 
 	/**
-	 * Adapts {@link JdbcKeysetProperties Konfigyr Keyseet JDBC properties} to
+	 * Adapts {@link JdbcKeysetProperties Konfigyr Keyset JDBC properties} to
 	 * {@link DatabaseInitializationSettings} replacing any <code>@@platform@@}</code>
 	 * placeholders.
 	 * @param dataSource spring data source
-	 * @param properties Konfigyr Keyseet JDBC properties
+	 * @param properties Konfigyr Keyset JDBC properties
 	 * @return a new {@link DatabaseInitializationSettings} instance
 	 */
 	static DatabaseInitializationSettings settings(DataSource dataSource, JdbcKeysetProperties properties) {
 		final DatabaseInitializationSettings settings = new DatabaseInitializationSettings();
 		settings.setSchemaLocations(resolveSchemaLocations(dataSource, properties));
-		settings.setMode(properties.getInitializeSchema());
+		settings.setMode(properties.initializeSchema());
 		settings.setContinueOnError(true);
 		return settings;
 	}
@@ -48,10 +48,10 @@ public class JdbcKeysetDataSourceScriptDatabaseInitializer extends DataSourceScr
 	private static List<String> resolveSchemaLocations(DataSource dataSource, JdbcKeysetProperties properties) {
 		PlatformPlaceholderDatabaseDriverResolver resolver = new PlatformPlaceholderDatabaseDriverResolver();
 		resolver = resolver.withDriverPlatform(DatabaseDriver.MARIADB, "mysql");
-		if (StringUtils.hasText(properties.getPlatform())) {
-			return resolver.resolveAll(properties.getPlatform(), properties.getSchema());
+		if (StringUtils.hasText(properties.platform())) {
+			return resolver.resolveAll(properties.platform(), properties.schema());
 		}
-		return resolver.resolveAll(dataSource, properties.getSchema());
+		return resolver.resolveAll(dataSource, properties.schema());
 	}
 
 }

--- a/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetProperties.java
+++ b/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetProperties.java
@@ -1,7 +1,7 @@
 package com.konfigyr.crypto.jdbc;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.boot.sql.init.DatabaseInitializationMode;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
@@ -12,58 +12,36 @@ import java.time.Duration;
  * Configuration properties for JDBC backed {@link com.konfigyr.crypto.KeysetRepository}
  * implementation.
  *
+ * @param schema Path to the SQL file used to initialize the database schema;
+ *   defaults to the bundled {@code schema-@@platform@@.sql} resource
+ * @param platform Platform name used to resolve the {@code @@platform@@} placeholder
+ *   in the schema location; when {@literal null} the datasource driver is used to determine
+ *   the platform
+ * @param initializeSchema Database schema initialization mode; defaults to
+ *   {@link DatabaseInitializationMode#EMBEDDED}
+ * @param tableName Name of the database table used to store {@link com.konfigyr.crypto.EncryptedKeyset
+ *   keyset} metadata; defaults to {@value JdbcKeysetRepository#DEFAULT_TABLE_NAME}
+ * @param keysTableName Name of the database table used to store {@link com.konfigyr.crypto.EncryptedKey
+ *   encrypted keys} with their lifecycle metadata; defaults to {@value JdbcKeysetRepository#DEFAULT_KEYS_TABLE_NAME}
+ * @param transactionIsolationLevel Transaction isolation level used by the {@link JdbcKeysetRepository}
+ *   when writing to the database; defaults to {@link Isolation#DEFAULT}
+ * @param transactionPropagationBehavior Transaction propagation behavior used by the
+ *   {@link JdbcKeysetRepository} when writing to the database; defaults to {@link Propagation#REQUIRED}
+ * @param transactionTimeout Transaction timeout used by the {@link JdbcKeysetRepository} when
+ *   writing to the database; defaults to 30 seconds
  * @author Vladimir Spasic
  * @since 1.0.0
  * @see JdbcKeysetRepository
  **/
-@Data
 @ConfigurationProperties(prefix = "konfigyr.crypto.jdbc")
-public class JdbcKeysetProperties {
-
-	/**
-	 * Path to the SQL file to use to initialize the database schema.
-	 */
-	private String schema = "classpath:com/konfigyr/crypto/jdbc/schema-@@platform@@.sql";
-
-	/**
-	 * Platform to use in initialization scripts if the <code>@@platform@@</code>
-	 * placeholder is used.
-	 */
-	private String platform;
-
-	/**
-	 * Database schema initialization mode.
-	 */
-	private DatabaseInitializationMode initializeSchema = DatabaseInitializationMode.EMBEDDED;
-
-	/**
-	 * Name of the database table used to store {@link com.konfigyr.crypto.EncryptedKeyset
-	 * keyset} metadata.
-	 */
-	private String tableName = JdbcKeysetRepository.DEFAULT_TABLE_NAME;
-
-	/**
-	 * Name of the database table used to store {@link com.konfigyr.crypto.EncryptedKey
-	 * encrypted keys} with their lifecycle metadata.
-	 */
-	private String keysTableName = JdbcKeysetRepository.DEFAULT_KEYS_TABLE_NAME;
-
-	/**
-	 * Specifies the transaction isolation level that is used by the {@link JdbcKeysetRepository} when writing
-	 * to the database. Defaults to {@link Isolation#DEFAULT}.
-	 */
-	private Isolation transactionIsolationLevel = Isolation.DEFAULT;
-
-	/**
-	 * Specifies the transaction propagation behavior that is used by the {@link JdbcKeysetRepository} when
-	 * writing to the database. Defaults to {@link Propagation#REQUIRED}.
-	 */
-	private Propagation transactionPropagationBehavior = Propagation.REQUIRED;
-
-	/**
-	 * Specifies the transaction timeout that is used by the {@link JdbcKeysetRepository} when writing
-	 * to the database. Defaults to 30 seconds.
-	 */
-	private Duration transactionTimeout = Duration.ofSeconds(30);
-
+public record JdbcKeysetProperties(
+		@DefaultValue("classpath:com/konfigyr/crypto/jdbc/schema-@@platform@@.sql") String schema,
+		String platform,
+		@DefaultValue("embedded") DatabaseInitializationMode initializeSchema,
+		@DefaultValue("KEYSETS") String tableName,
+		@DefaultValue("KEYSET_KEYS") String keysTableName,
+		@DefaultValue("DEFAULT") Isolation transactionIsolationLevel,
+		@DefaultValue("REQUIRED") Propagation transactionPropagationBehavior,
+		@DefaultValue("30s") Duration transactionTimeout
+) {
 }

--- a/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
+++ b/konfigyr-crypto-jdbc/src/main/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepository.java
@@ -3,11 +3,10 @@ package com.konfigyr.crypto.jdbc;
 import com.konfigyr.crypto.*;
 import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -71,9 +70,6 @@ import java.util.Optional;
  * @author Vladimir Spasic
  * @since 1.0.0
  **/
-@Slf4j
-@Setter
-@RequiredArgsConstructor
 public class JdbcKeysetRepository implements KeysetRepository, InitializingBean {
 
 	/**
@@ -228,6 +224,189 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 
 	private final TransactionOperations transactionOperations;
 
+	private final Logger log = LoggerFactory.getLogger(JdbcKeysetRepository.class);
+
+	/**
+	 * Creates a new {@link JdbcKeysetRepository} backed by the given JDBC and transaction operations.
+	 *
+	 * @param jdbcOperations the JDBC operations used to execute database queries, can't be {@literal null}
+	 * @param transactionOperations the transaction operations used to wrap writes in a transaction, can't be {@literal null}
+	 */
+	public JdbcKeysetRepository(JdbcOperations jdbcOperations, TransactionOperations transactionOperations) {
+		this.jdbcOperations = jdbcOperations;
+		this.transactionOperations = transactionOperations;
+	}
+
+	/**
+	 * Sets the name of the database table used to store keyset metadata.
+	 * Defaults to {@value DEFAULT_TABLE_NAME}.
+	 *
+	 * @param tableName the table name, can't be {@literal null}
+	 */
+	public void setTableName(String tableName) {
+		this.tableName = tableName;
+	}
+
+	/**
+	 * Sets the name of the database table used to store encrypted key entries.
+	 * Defaults to {@value DEFAULT_KEYS_TABLE_NAME}.
+	 *
+	 * @param keysTableName the keys table name, can't be {@literal null}
+	 */
+	public void setKeysTableName(String keysTableName) {
+		this.keysTableName = keysTableName;
+	}
+
+	/**
+	 * Overrides the SQL query used to read a keyset by name.
+	 * When {@literal null}, the built-in default query is used.
+	 *
+	 * @param getKeysetQuery custom SQL query, or {@literal null} to use the default
+	 */
+	public void setGetKeysetQuery(String getKeysetQuery) {
+		this.getKeysetQuery = getKeysetQuery;
+	}
+
+	/**
+	 * Overrides the SQL query used to read the keys belonging to a keyset.
+	 * When {@literal null}, the built-in default query is used.
+	 *
+	 * @param getKeysQuery custom SQL query, or {@literal null} to use the default
+	 */
+	public void setGetKeysQuery(String getKeysQuery) {
+		this.getKeysQuery = getKeysQuery;
+	}
+
+	/**
+	 * Overrides the SQL query used to check whether a keyset exists.
+	 * When {@literal null}, the built-in default query is used.
+	 *
+	 * @param keysetExistsQuery custom SQL query, or {@literal null} to use the default
+	 */
+	public void setKeysetExistsQuery(String keysetExistsQuery) {
+		this.keysetExistsQuery = keysetExistsQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to insert a new keyset row.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param createKeysetQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setCreateKeysetQuery(String createKeysetQuery) {
+		this.createKeysetQuery = createKeysetQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to update an existing keyset row.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param updateKeysetQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setUpdateKeysetQuery(String updateKeysetQuery) {
+		this.updateKeysetQuery = updateKeysetQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to insert a new key row.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param createKeyQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setCreateKeyQuery(String createKeyQuery) {
+		this.createKeyQuery = createKeyQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to update an existing key row.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param updateKeyQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setUpdateKeyQuery(String updateKeyQuery) {
+		this.updateKeyQuery = updateKeyQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to delete a single key row.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param deleteKeyQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setDeleteKeyQuery(String deleteKeyQuery) {
+		this.deleteKeyQuery = deleteKeyQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to delete all key rows for a keyset.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param deleteKeysQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setDeleteKeysQuery(String deleteKeysQuery) {
+		this.deleteKeysQuery = deleteKeysQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to delete a keyset row.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param deleteKeysetQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setDeleteKeysetQuery(String deleteKeysetQuery) {
+		this.deleteKeysetQuery = deleteKeysetQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to update the lifecycle status of a key.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param updateKeyStatusQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setUpdateKeyStatusQuery(String updateKeyStatusQuery) {
+		this.updateKeyStatusQuery = updateKeyStatusQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to permanently destroy a key (clear its material and mark it destroyed).
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param destroyKeyQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setDestroyKeyQuery(String destroyKeyQuery) {
+		this.destroyKeyQuery = destroyKeyQuery;
+	}
+
+	/**
+	 * Overrides the SQL query used to find keysets that have keys pending destruction.
+	 * When {@literal null}, the built-in default query is used.
+	 *
+	 * @param findPendingDestructionQuery custom SQL query, or {@literal null} to use the default
+	 */
+	public void setFindPendingDestructionQuery(String findPendingDestructionQuery) {
+		this.findPendingDestructionQuery = findPendingDestructionQuery;
+	}
+
+	/**
+	 * Overrides the SQL query used to find keysets whose primary key has passed its rotation interval.
+	 * When {@literal null}, the built-in default query is used.
+	 *
+	 * @param findPendingRotationQuery custom SQL query, or {@literal null} to use the default
+	 */
+	public void setFindPendingRotationQuery(String findPendingRotationQuery) {
+		this.findPendingRotationQuery = findPendingRotationQuery;
+	}
+
+	/**
+	 * Overrides the SQL statement used to increment the keyset version counter.
+	 * When {@literal null}, the built-in default statement is used.
+	 *
+	 * @param bumpKeysetVersionQuery custom SQL statement, or {@literal null} to use the default
+	 */
+	public void setBumpKeysetVersionQuery(String bumpKeysetVersionQuery) {
+		this.bumpKeysetVersionQuery = bumpKeysetVersionQuery;
+	}
+
 	@Override
 	public void afterPropertiesSet() {
 		Assert.hasText(tableName, "Table name for encrypted keysets can not be blank");
@@ -280,7 +459,7 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 	@Override
 	public EncryptedKeyset write(@NonNull EncryptedKeyset keyset) {
 		return transactionOperations.execute(status -> {
-			if (exists(keyset.getName())) {
+			if (exists(keyset.name())) {
 				return update(keyset);
 			}
 
@@ -300,56 +479,63 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 	}
 
 	private void create(EncryptedKeyset keyset) {
-		log.debug("Creating keyset '{}' with {} key(s)", keyset.getName(), keyset.size());
+		log.debug("Creating keyset '{}' with {} key(s)", keyset.name(), keyset.size());
 
 		jdbcOperations.update(createKeysetQuery, ps -> {
-			ps.setString(1, keyset.getName());
-			ps.setString(2, keyset.getPurpose());
-			ps.setString(3, keyset.getFactory());
-			ps.setString(4, keyset.getProvider());
-			ps.setString(5, keyset.getKeyEncryptionKey());
-			setDuration(ps, 6, keyset.getRotationInterval());
-			setDuration(ps, 7, keyset.getDestructionGracePeriod());
+			ps.setString(1, keyset.name());
+			ps.setString(2, keyset.purpose());
+			ps.setString(3, keyset.factory());
+			ps.setString(4, keyset.provider());
+			ps.setString(5, keyset.keyEncryptionKey());
+			setDuration(ps, 6, keyset.rotationInterval());
+			setDuration(ps, 7, keyset.destructionGracePeriod());
 		});
-		insertKeys(keyset.getName(), keyset.getKeys());
+		insertKeys(keyset.name(), keyset.keys());
 	}
 
 	private EncryptedKeyset update(EncryptedKeyset keyset) {
-		log.debug("Updating keyset '{}'", keyset.getName());
+		log.debug("Updating keyset '{}'", keyset.name());
 
 		final int updated = jdbcOperations.update(updateKeysetQuery, ps -> {
-			ps.setString(1, keyset.getPurpose());
-			ps.setString(2, keyset.getFactory());
-			ps.setString(3, keyset.getProvider());
-			ps.setString(4, keyset.getKeyEncryptionKey());
-			setDuration(ps, 5, keyset.getRotationInterval());
-			setDuration(ps, 6, keyset.getDestructionGracePeriod());
-			ps.setString(7, keyset.getName());
-			ps.setLong(8, keyset.getVersion());
+			ps.setString(1, keyset.purpose());
+			ps.setString(2, keyset.factory());
+			ps.setString(3, keyset.provider());
+			ps.setString(4, keyset.keyEncryptionKey());
+			setDuration(ps, 5, keyset.rotationInterval());
+			setDuration(ps, 6, keyset.destructionGracePeriod());
+			ps.setString(7, keyset.name());
+			ps.setLong(8, keyset.version());
 		});
 
 		if (updated == 0) {
-			throw new CryptoException.KeysetConcurrentModificationException(keyset.getName());
+			throw new CryptoException.KeysetConcurrentModificationException(keyset.name());
 		}
 
-		updateKeys(keyset.getName(), keyset.getKeys());
-		return EncryptedKeyset.builder(keyset).version(keyset.getVersion() + 1).build(keyset.getKeys());
+		updateKeys(keyset.name(), keyset.keys());
+		return EncryptedKeyset.builder(keyset).version(keyset.version() + 1).build(keyset.keys());
 	}
 
-	private void updateKeys(String keysetName, List<EncryptedKey> newKeys) {
+	/**
+	 * Synchronizes the set of {@link EncryptedKey keys} for the given keyset in the database.
+	 * Keys absent from {@code newKeys} are deleted; new entries are inserted; changed entries are updated.
+	 *
+	 * @param keysetName the name of the keyset whose keys are being synchronized, can't be {@literal null}
+	 * @param newKeys the desired list of encrypted keys, can't be {@literal null}
+	 */
+	protected void updateKeys(String keysetName, List<EncryptedKey> newKeys) {
 		final List<EncryptedKey> stored = jdbcOperations.query(
 			getKeysQuery, pss -> pss.setString(1, keysetName), this::extractKeys);
 
 		final Map<String, EncryptedKey> storedById = new HashMap<>(stored.size());
 		for (EncryptedKey key : stored) {
-			storedById.put(key.getId(), key);
+			storedById.put(key.id(), key);
 		}
 
 		final List<EncryptedKey> toInsert = new ArrayList<>();
 		final List<EncryptedKey> toUpdate = new ArrayList<>();
 
 		for (EncryptedKey key : newKeys) {
-			final EncryptedKey existing = storedById.remove(key.getId());
+			final EncryptedKey existing = storedById.remove(key.id());
 			if (existing == null) {
 				toInsert.add(key);
 			}
@@ -359,8 +545,8 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 		}
 
 		final List<String> toDelete = storedById.values().stream()
-			.filter(key -> key.getData() != null)
-			.map(EncryptedKey::getId)
+			.filter(key -> key.data() != null)
+			.map(EncryptedKey::id)
 			.toList();
 
 		if (log.isDebugEnabled()) {
@@ -375,18 +561,18 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 
 		if (!toUpdate.isEmpty()) {
 			jdbcOperations.batchUpdate(updateKeyQuery, toUpdate, toUpdate.size(), (ps, key) -> {
-				ps.setString(1, key.getAlgorithm());
-				ps.setString(2, key.getType().name());
-				ps.setString(3, key.getStatus().name());
-				ps.setBoolean(4, key.isPrimary());
-				setBytes(ps, 5, key.getData());
-				ps.setLong(6, key.getCreatedAt().toEpochMilli());
-				setInstant(ps, 7, key.getInitializedAt());
-				setInstant(ps, 8, key.getExpiresAt());
-				setInstant(ps, 9, key.getDestructionScheduledAt());
-				setInstant(ps, 10, key.getDestroyedAt());
+				ps.setString(1, key.algorithm());
+				ps.setString(2, key.type().name());
+				ps.setString(3, key.status().name());
+				ps.setBoolean(4, key.primary());
+				setBytes(ps, 5, key.data());
+				ps.setLong(6, key.createdAt().toEpochMilli());
+				setInstant(ps, 7, key.initializedAt());
+				setInstant(ps, 8, key.expiresAt());
+				setInstant(ps, 9, key.destructionScheduledAt());
+				setInstant(ps, 10, key.destroyedAt());
 				ps.setString(11, keysetName);
-				ps.setString(12, key.getId());
+				ps.setString(12, key.id());
 			});
 		}
 
@@ -398,51 +584,57 @@ public class JdbcKeysetRepository implements KeysetRepository, InitializingBean 
 		}
 	}
 
-	private void insertKeys(String keysetName, List<EncryptedKey> keys) {
+	/**
+	 * Inserts the given list of {@link EncryptedKey keys} for the specified keyset into the database.
+	 *
+	 * @param keysetName the name of the keyset the keys belong to, can't be {@literal null}
+	 * @param keys the keys to insert, can't be {@literal null}
+	 */
+	protected void insertKeys(String keysetName, List<EncryptedKey> keys) {
 		jdbcOperations.batchUpdate(createKeyQuery, keys, keys.size(), (ps, key) -> {
 			ps.setString(1, keysetName);
-			ps.setString(2, key.getId());
-			ps.setString(3, key.getAlgorithm());
-			ps.setString(4, key.getType().name());
-			ps.setString(5, key.getStatus().name());
-			ps.setBoolean(6, key.isPrimary());
-			setBytes(ps, 7, key.getData());
-			ps.setLong(8, key.getCreatedAt().toEpochMilli());
-			setInstant(ps, 9, key.getInitializedAt());
-			setInstant(ps, 10, key.getExpiresAt());
-			setInstant(ps, 11, key.getDestructionScheduledAt());
-			setInstant(ps, 12, key.getDestroyedAt());
+			ps.setString(2, key.id());
+			ps.setString(3, key.algorithm());
+			ps.setString(4, key.type().name());
+			ps.setString(5, key.status().name());
+			ps.setBoolean(6, key.primary());
+			setBytes(ps, 7, key.data());
+			ps.setLong(8, key.createdAt().toEpochMilli());
+			setInstant(ps, 9, key.initializedAt());
+			setInstant(ps, 10, key.expiresAt());
+			setInstant(ps, 11, key.destructionScheduledAt());
+			setInstant(ps, 12, key.destroyedAt());
 		});
 	}
 
 	@Override
 	public void updateKeyStatus(@NonNull KeyTransition transition) {
 		log.debug("Updating key '{}' in keyset '{}' to status {}",
-				transition.getKeyId(), transition.getKeysetName(), transition.getStatus());
+				transition.keyId(), transition.keysetName(), transition.status());
 
 		transactionOperations.executeWithoutResult(status -> {
-			if (transition.getStatus() == KeyStatus.DESTROYED) {
+			if (transition.status() == KeyStatus.DESTROYED) {
 				jdbcOperations.update(destroyKeyQuery, ps -> {
-					setInstant(ps, 1, transition.getDestroyedAt());
-					ps.setString(2, transition.getKeysetName());
-					ps.setString(3, transition.getKeyId());
+					setInstant(ps, 1, transition.destroyedAt());
+					ps.setString(2, transition.keysetName());
+					ps.setString(3, transition.keyId());
 				});
 			}
 			else {
 				jdbcOperations.update(updateKeyStatusQuery, ps -> {
-					ps.setString(1, transition.getStatus().name());
-					setInstant(ps, 2, transition.getDestructionScheduledAt());
-					setInstant(ps, 3, transition.getDestroyedAt());
-					ps.setString(4, transition.getKeysetName());
-					ps.setString(5, transition.getKeyId());
+					ps.setString(1, transition.status().name());
+					setInstant(ps, 2, transition.destructionScheduledAt());
+					setInstant(ps, 3, transition.destroyedAt());
+					ps.setString(4, transition.keysetName());
+					ps.setString(5, transition.keyId());
 				});
 			}
 			final int bumped = jdbcOperations.update(bumpKeysetVersionQuery, pss -> {
-				pss.setString(1, transition.getKeysetName());
-				pss.setLong(2, transition.getKeysetVersion());
+				pss.setString(1, transition.keysetName());
+				pss.setLong(2, transition.keysetVersion());
 			});
 			if (bumped == 0) {
-				throw new CryptoException.KeysetConcurrentModificationException(transition.getKeysetName());
+				throw new CryptoException.KeysetConcurrentModificationException(transition.keysetName());
 			}
 		});
 	}

--- a/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
+++ b/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
@@ -431,6 +431,30 @@ class JdbcKeysetRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("should accept custom SQL query overrides and still resolve defaults when null is provided")
+	void shouldAcceptCustomSqlQueryOverrides() {
+		final var repo = new JdbcKeysetRepository(jdbcOperations, transactionOperations);
+		repo.setGetKeysetQuery(null);
+		repo.setGetKeysQuery(null);
+		repo.setKeysetExistsQuery(null);
+		repo.setCreateKeysetQuery(null);
+		repo.setUpdateKeysetQuery(null);
+		repo.setCreateKeyQuery(null);
+		repo.setUpdateKeyQuery(null);
+		repo.setDeleteKeyQuery(null);
+		repo.setDeleteKeysQuery(null);
+		repo.setDeleteKeysetQuery(null);
+		repo.setUpdateKeyStatusQuery(null);
+		repo.setDestroyKeyQuery(null);
+		repo.setFindPendingDestructionQuery(null);
+		repo.setFindPendingRotationQuery(null);
+		repo.setBumpKeysetVersionQuery(null);
+		repo.afterPropertiesSet();
+
+		assertThat(repo.read("non-existent")).isEmpty();
+	}
+
+	@Test
 	@DisplayName("should reject table names that are not valid SQL identifiers")
 	void shouldRejectInvalidTableNames() {
 		final var repo = new JdbcKeysetRepository(jdbcOperations, transactionOperations);

--- a/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
+++ b/konfigyr-crypto-jdbc/src/test/java/com/konfigyr/crypto/jdbc/JdbcKeysetRepositoryTest.java
@@ -12,6 +12,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.transaction.support.TransactionOperations;
 
@@ -92,7 +94,7 @@ class JdbcKeysetRepositoryTest {
 		assertThat(repository.read(definition.getName())).isNotEmpty().hasValue(metadataOnly);
 
 		// --- remove ---
-		repository.remove(metadataOnly.getName());
+		repository.remove(metadataOnly.name());
 		assertThat(repository.read(definition.getName())).isEmpty();
 	}
 
@@ -112,8 +114,8 @@ class JdbcKeysetRepositoryTest {
 				assertThat(ks.getKey("key-1"))
 					.isPresent()
 					.hasValueSatisfying(k -> {
-						assertThat(k.getStatus()).isEqualTo(KeyStatus.DISABLED);
-						assertThat(k.getData()).isNotNull();
+						assertThat(k.status()).isEqualTo(KeyStatus.DISABLED);
+						assertThat(k.data()).isNotNull();
 					})
 			);
 
@@ -145,9 +147,9 @@ class JdbcKeysetRepositoryTest {
 				assertThat(ks.getKey("key-1"))
 					.isPresent()
 					.hasValueSatisfying(k -> {
-						assertThat(k.getStatus()).isEqualTo(KeyStatus.DESTROYED);
-						assertThat(k.getData()).isNull();
-						assertThat(k.getDestroyedAt()).isEqualTo(destroyedAt);
+						assertThat(k.status()).isEqualTo(KeyStatus.DESTROYED);
+						assertThat(k.data()).isNull();
+						assertThat(k.destroyedAt()).isEqualTo(destroyedAt);
 					})
 			);
 
@@ -186,11 +188,11 @@ class JdbcKeysetRepositoryTest {
 		assertThat(results)
 			.hasSize(1)
 			.first()
-			.returns("lifecycle-pending", EncryptedKeyset::getName)
-			.extracting(EncryptedKeyset::getKeys, InstanceOfAssertFactories.iterable(EncryptedKey.class))
+			.returns("lifecycle-pending", EncryptedKeyset::name)
+			.extracting(EncryptedKeyset::keys, InstanceOfAssertFactories.iterable(EncryptedKey.class))
 			.hasSize(1)
 			.first()
-			.returns("past-key", EncryptedKey::getId);
+			.returns("past-key", EncryptedKey::id);
 
 		repository.remove("lifecycle-pending");
 	}
@@ -211,7 +213,7 @@ class JdbcKeysetRepositoryTest {
 		repository.write(encryptedKeyset("lifecycle-future", futureKey));
 
 		assertThat(repository.findPendingDestruction())
-			.extracting(EncryptedKeyset::getName)
+			.extracting(EncryptedKeyset::name)
 			.doesNotContain("lifecycle-future");
 
 		repository.remove("lifecycle-future");
@@ -236,12 +238,12 @@ class JdbcKeysetRepositoryTest {
 		final var results = repository.findPendingRotation();
 
 		assertThat(results)
-			.extracting(EncryptedKeyset::getName)
+			.extracting(EncryptedKeyset::name)
 			.contains("rotation-due");
 		assertThat(results)
-			.filteredOn(ks -> "rotation-due".equals(ks.getName()))
+			.filteredOn(ks -> "rotation-due".equals(ks.name()))
 			.first()
-			.extracting(EncryptedKeyset::getKeys)
+			.extracting(EncryptedKeyset::keys)
 			.isEqualTo(List.of());
 
 		repository.remove("rotation-due");
@@ -264,7 +266,7 @@ class JdbcKeysetRepositoryTest {
 		repository.write(encryptedKeyset("rotation-not-due", primaryKey));
 
 		assertThat(repository.findPendingRotation())
-			.extracting(EncryptedKeyset::getName)
+			.extracting(EncryptedKeyset::name)
 			.doesNotContain("rotation-not-due");
 
 		repository.remove("rotation-not-due");
@@ -322,14 +324,14 @@ class JdbcKeysetRepositoryTest {
 		assertThat(stored.getKey("old-key"))
 			.isPresent()
 			.hasValueSatisfying(key -> {
-				assertThat(key.getStatus()).isEqualTo(KeyStatus.DESTROYED);
-				assertThat(key.getData()).isNull();
-				assertThat(key.getDestroyedAt()).isEqualTo(destroyedAt);
+				assertThat(key.status()).isEqualTo(KeyStatus.DESTROYED);
+				assertThat(key.data()).isNull();
+				assertThat(key.destroyedAt()).isEqualTo(destroyedAt);
 			});
 
 		assertThat(stored.getKey("primary-key"))
 			.isPresent()
-			.hasValueSatisfying(key -> assertThat(key.getData()).isNotNull());
+			.hasValueSatisfying(key -> assertThat(key.data()).isNotNull());
 
 		repository.remove("keyset");
 	}
@@ -367,6 +369,65 @@ class JdbcKeysetRepositoryTest {
 				.isInstanceOf(CryptoException.KeysetConcurrentModificationException.class);
 
 		repository.remove("status-conflict");
+	}
+
+	@Test
+	@DisplayName("should roll back KEYSETS row when insertKeys throws during create")
+	void shouldRollbackCreateOnInsertKeysFailure() throws IOException {
+		final String name = "rollback-create";
+		final Instant t0 = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+		final EncryptedKey key = encryptedKey("key-1", true, t0, ByteArray.fromString("key-material"));
+		final EncryptedKeyset keyset = encryptedKeyset(name, key);
+
+		final JdbcKeysetRepository failingRepo = new JdbcKeysetRepository(jdbcOperations, transactionOperations) {
+			@Override
+			protected void insertKeys(String keysetName, List<EncryptedKey> keys) {
+				throw new DataIntegrityViolationException("simulated key insertion failure");
+			}
+		};
+		failingRepo.afterPropertiesSet();
+
+		try {
+			assertThatThrownBy(() -> failingRepo.write(keyset))
+				.isInstanceOf(DataAccessException.class);
+
+			assertThat(repository.read(name)).isEmpty();
+		} finally {
+			repository.remove(name);
+		}
+	}
+
+	@Test
+	@DisplayName("should roll back KEYSETS update when updateKeys throws during update")
+	void shouldRollbackUpdateOnUpdateKeysSyncFailure() throws IOException {
+		final String name = "rollback-update";
+		final Instant t0 = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+		final EncryptedKey originalKey = encryptedKey("key-1", true, t0, ByteArray.fromString("original-material"));
+		final EncryptedKeyset original = encryptedKeyset(name, originalKey);
+
+		final EncryptedKeyset written = repository.write(original);
+
+		final JdbcKeysetRepository failingRepo = new JdbcKeysetRepository(jdbcOperations, transactionOperations) {
+			@Override
+			protected void updateKeys(String keysetName, List<EncryptedKey> newKeys) {
+				throw new DataIntegrityViolationException("simulated key sync failure");
+			}
+		};
+		failingRepo.afterPropertiesSet();
+
+		try {
+			final EncryptedKey newKey = encryptedKey("key-2", false, t0.plusSeconds(1), ByteArray.fromString("new-material"));
+			final EncryptedKeyset updated = EncryptedKeyset.builder(written).build(originalKey, newKey);
+
+			assertThatThrownBy(() -> failingRepo.write(updated))
+				.isInstanceOf(DataAccessException.class);
+
+			assertThat(repository.read(name))
+				.isNotEmpty()
+				.hasValue(original);
+		} finally {
+			repository.remove(name);
+		}
 	}
 
 	@Test

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAlgorithm.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAlgorithm.java
@@ -11,13 +11,13 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jose.jwk.gen.JWKGenerator;
 import com.nimbusds.jose.jwk.gen.OctetSequenceKeyGenerator;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
-import lombok.EqualsAndHashCode;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.util.Assert;
 
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -43,7 +43,6 @@ import java.util.function.Supplier;
  * @see com.nimbusds.jose.JWEAlgorithm
  */
 @NullMarked
-@EqualsAndHashCode(of = "name")
 public final class JoseAlgorithm implements Algorithm {
 
 	/* -------------------------------------------------------------------------
@@ -316,10 +315,19 @@ public final class JoseAlgorithm implements Algorithm {
 	 */
 	public static final List<JoseAlgorithm> LEGACY_ALGORITHMS = List.of(RS256, RS384, RS512);
 
+	/** Stable unique algorithm name with {@code "jose:"} prefix. */
 	private final String name;
+
+	/** Key material type produced by this algorithm. */
 	private final KeyType type;
+
+	/** Intended cryptographic purpose (signing or encryption). */
 	private final KeysetPurpose purpose;
+
+	/** Backing Nimbus JOSE algorithm identifier used for JWS/JWE operations. */
 	private final com.nimbusds.jose.Algorithm algorithm;
+
+	/** Factory that creates a fresh {@link JWKGenerator} instance per key-generation request. */
 	private final Supplier<JWKGenerator<? extends JWK>> generator;
 
 	/**
@@ -392,6 +400,18 @@ public final class JoseAlgorithm implements Algorithm {
 			.keyUse(JoseUtils.resolveKeyUse(purpose))
 			.keyOperations(JoseUtils.resolveKeyOperations(purpose))
 			.notBeforeTime(Date.from(Instant.ofEpochSecond(System.currentTimeMillis() / 1000)));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof JoseAlgorithm that)) return false;
+		return Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
 	}
 
 	@Override

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAutoConfiguration.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseAutoConfiguration.java
@@ -22,6 +22,12 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnMissingBean(JoseKeysetFactory.class)
 public class JoseAutoConfiguration {
 
+	/**
+	 * Creates a new {@link JoseAutoConfiguration} instance.
+	 */
+	public JoseAutoConfiguration() {
+	}
+
 	@Bean
 	AlgorithmRegistrar joseAlgorithmRegistrar() {
 		return registry -> JoseAlgorithm.DEFAULT_ALGORITHMS.forEach(registry::register);

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseKeysetFactory.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JoseKeysetFactory.java
@@ -4,7 +4,6 @@ import com.konfigyr.crypto.*;
 import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
 import com.nimbusds.jose.jwk.JWK;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 
 import java.nio.charset.StandardCharsets;
@@ -35,12 +34,20 @@ import java.util.List;
  * @see JsonWebKeyset
  **/
 @NullMarked
-@RequiredArgsConstructor
 public class JoseKeysetFactory implements KeysetFactory {
 
 	static final String NAME = "jose";
 
 	private final AlgorithmRegistry registry;
+
+	/**
+	 * Creates a new {@link JoseKeysetFactory} that resolves algorithms from the given registry.
+	 *
+	 * @param registry the algorithm registry used to look up {@link JoseAlgorithm} instances, can't be {@literal null}
+	 */
+	public JoseKeysetFactory(AlgorithmRegistry registry) {
+		this.registry = registry;
+	}
 
 	@Override
 	public String getName() {
@@ -87,31 +94,31 @@ public class JoseKeysetFactory implements KeysetFactory {
 			.keyEncryptionKey(kek);
 
 		for (EncryptedKey encrypted : encryptedKeyset) {
-			if (encrypted.getData() == null) {
+			if (encrypted.data() == null) {
 				continue;
 			}
 
 			final JWK key;
 
 			try {
-				final ByteArray unwrapped = kek.unwrap(encrypted.getData());
+				final ByteArray unwrapped = kek.unwrap(encrypted.data());
 				key = JWK.parse(unwrapped.toString(StandardCharsets.UTF_8));
 			} catch (Exception e) {
-				throw new CryptoException.UnwrappingException(encryptedKeyset.getName(), kek, e);
+				throw new CryptoException.UnwrappingException(encryptedKeyset.name(), kek, e);
 			}
 
-			final JoseAlgorithm algorithm = (JoseAlgorithm) registry.resolve(encrypted.getAlgorithm());
+			final JoseAlgorithm algorithm = (JoseAlgorithm) registry.resolve(encrypted.algorithm());
 
 			builder.key(new JsonWebKey.Builder(key)
-				.id(encrypted.getId())
-				.status(encrypted.getStatus())
+				.id(encrypted.id())
+				.status(encrypted.status())
 				.algorithm(algorithm)
-				.primary(encrypted.isPrimary())
-				.createdAt(encrypted.getCreatedAt())
-				.initializedAt(encrypted.getInitializedAt())
-				.expiresAt(encrypted.getExpiresAt())
-				.destructionScheduledAt(encrypted.getDestructionScheduledAt())
-				.destroyedAt(encrypted.getDestroyedAt())
+				.primary(encrypted.primary())
+				.createdAt(encrypted.createdAt())
+				.initializedAt(encrypted.initializedAt())
+				.expiresAt(encrypted.expiresAt())
+				.destructionScheduledAt(encrypted.destructionScheduledAt())
+				.destroyedAt(encrypted.destroyedAt())
 				.build()
 			);
 		}

--- a/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JsonWebKey.java
+++ b/konfigyr-crypto-jose/src/main/java/com/konfigyr/crypto/jose/JsonWebKey.java
@@ -6,14 +6,16 @@ import com.konfigyr.crypto.KeyDefinition;
 import com.konfigyr.crypto.KeyStatus;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
-import lombok.Getter;
 import org.jspecify.annotations.NullMarked;
 
-@Getter
 @NullMarked
 class JsonWebKey extends AbstractKey<JoseAlgorithm> {
 
 	JWK value;
+
+	JWK getValue() {
+		return value;
+	}
 
 	JsonWebKey(JWK value, Builder builder) {
 		super(builder);

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseAlgorithmTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseAlgorithmTest.java
@@ -1,0 +1,49 @@
+package com.konfigyr.crypto.jose;
+
+import com.konfigyr.crypto.KeyType;
+import com.konfigyr.crypto.KeysetPurpose;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class JoseAlgorithmTest {
+
+	@Test
+	@DisplayName("should fail to create algorithm without a valid `jose:` prefix")
+	void shouldAssertJosePrefix() {
+		assertThatIllegalArgumentException().isThrownBy(() ->new JoseAlgorithm(
+			"RS256", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.RS256,
+			() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+		)).withMessage("JOSE algorithm names must start with 'jose:' prefix");
+	}
+
+	@Test
+	@DisplayName("should consider two algorithms with the same name equal")
+	void shouldBeEqualByName() {
+		final var algorithm = new JoseAlgorithm(
+			"jose:RS256", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.RS256,
+			() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+		);
+
+		assertThat(algorithm)
+			.isEqualTo(JoseAlgorithm.RS256)
+			.hasSameHashCodeAs(JoseAlgorithm.RS256);
+
+		assertThat(algorithm)
+			.isNotEqualTo(JoseAlgorithm.ES256);
+	}
+
+	@Test
+	@DisplayName("should produce a non-blank toString")
+	void shouldProduceNonBlankToString() {
+		assertThat(JoseAlgorithm.RS256)
+			.hasToString("jose:RS256");
+		assertThat(JoseAlgorithm.ES256)
+			.hasToString("jose:ES256");
+	}
+
+}

--- a/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseAlgorithmTest.java
+++ b/konfigyr-crypto-jose/src/test/java/com/konfigyr/crypto/jose/JoseAlgorithmTest.java
@@ -15,7 +15,7 @@ class JoseAlgorithmTest {
 	@Test
 	@DisplayName("should fail to create algorithm without a valid `jose:` prefix")
 	void shouldAssertJosePrefix() {
-		assertThatIllegalArgumentException().isThrownBy(() ->new JoseAlgorithm(
+		assertThatIllegalArgumentException().isThrownBy(() -> new JoseAlgorithm(
 			"RS256", KeyType.RSA, KeysetPurpose.SIGNING, JWSAlgorithm.RS256,
 			() -> new RSAKeyGenerator(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
 		)).withMessage("JOSE algorithm names must start with 'jose:' prefix");

--- a/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/AbstractKeysetFactoryTest.java
+++ b/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/AbstractKeysetFactoryTest.java
@@ -47,6 +47,12 @@ import static org.assertj.core.api.Assertions.*;
 public abstract class AbstractKeysetFactoryTest {
 
 	/**
+	 * Creates a new instance of this abstract test class.
+	 */
+	protected AbstractKeysetFactoryTest() {
+	}
+
+	/**
 	 * Returns the {@link KeysetFactory} under test.
 	 *
 	 * @return factory under test, never {@literal null}

--- a/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/EncryptedKeyAssert.java
+++ b/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/EncryptedKeyAssert.java
@@ -81,7 +81,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	 */
 	public EncryptedKeyAssert hasId(@Nullable String id) {
 		assertThatKey()
-			.extracting(EncryptedKey::getId, InstanceOfAssertFactories.STRING)
+			.extracting(EncryptedKey::id, InstanceOfAssertFactories.STRING)
 			.as("key identifier")
 			.isEqualTo(id);
 		return myself;
@@ -105,7 +105,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	 */
 	public EncryptedKeyAssert hasAlgorithm(@Nullable String algorithm) {
 		assertThatKey()
-			.extracting(EncryptedKey::getAlgorithm, InstanceOfAssertFactories.STRING)
+			.extracting(EncryptedKey::algorithm, InstanceOfAssertFactories.STRING)
 			.as("key algorithm")
 			.isEqualTo(algorithm);
 		return myself;
@@ -119,7 +119,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	 */
 	public EncryptedKeyAssert hasType(@Nullable KeyType type) {
 		assertThatKey()
-			.extracting(EncryptedKey::getType)
+			.extracting(EncryptedKey::type)
 			.as("key type")
 			.isEqualTo(type);
 		return myself;
@@ -143,7 +143,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	public EncryptedKeyAssert hasStatus(@Nullable KeyStatus status) {
 		isNotNull();
 		assertThatKey()
-			.extracting(EncryptedKey::getStatus)
+			.extracting(EncryptedKey::status)
 			.as("key status")
 			.isEqualTo(status);
 		return myself;
@@ -176,7 +176,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	public EncryptedKeyAssert isPrimary(boolean primary) {
 		isNotNull();
 		assertThatKey()
-			.extracting(EncryptedKey::isPrimary, InstanceOfAssertFactories.BOOLEAN)
+			.extracting(EncryptedKey::primary, InstanceOfAssertFactories.BOOLEAN)
 			.as("key primary flag")
 			.isEqualTo(primary);
 		return myself;
@@ -212,7 +212,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	public EncryptedKeyAssert hasMaterial(@Nullable WrappedKeyMaterial material) {
 		isNotNull();
 		assertThatKey()
-			.extracting(EncryptedKey::getData)
+			.extracting(EncryptedKey::data)
 			.as("key material")
 			.isEqualTo(material);
 		return myself;
@@ -236,7 +236,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	 * @return this assertion for chaining, never {@literal null}
 	 */
 	public EncryptedKeyAssert isCreatedAt(@Nullable Instant createdAt, Duration tolerance) {
-		return assertInstant(EncryptedKey::getCreatedAt, createdAt, tolerance, "key creation timestamp");
+		return assertInstant(EncryptedKey::createdAt, createdAt, tolerance, "key creation timestamp");
 	}
 
 	/**
@@ -257,7 +257,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	 * @return this assertion for chaining, never {@literal null}
 	 */
 	public EncryptedKeyAssert isInitializedAt(@Nullable Instant initializedAt, Duration tolerance) {
-		return assertInstant(EncryptedKey::getInitializedAt, initializedAt, tolerance, "key initialization timestamp");
+		return assertInstant(EncryptedKey::initializedAt, initializedAt, tolerance, "key initialization timestamp");
 	}
 
 	/**
@@ -278,7 +278,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	 * @return this assertion for chaining, never {@literal null}
 	 */
 	public EncryptedKeyAssert expiresAt(@Nullable Instant expiresAt, Duration tolerance) {
-		return assertInstant(EncryptedKey::getExpiresAt, expiresAt, tolerance, "key expiry timestamp");
+		return assertInstant(EncryptedKey::expiresAt, expiresAt, tolerance, "key expiry timestamp");
 	}
 
 	/**
@@ -299,7 +299,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	 * @return this assertion for chaining, never {@literal null}
 	 */
 	public EncryptedKeyAssert destructionScheduledAt(@Nullable Instant destructionScheduledAt, Duration tolerance) {
-		return assertInstant(EncryptedKey::getDestructionScheduledAt, destructionScheduledAt, tolerance,
+		return assertInstant(EncryptedKey::destructionScheduledAt, destructionScheduledAt, tolerance,
 			"key scheduled destruction timestamp");
 	}
 
@@ -321,7 +321,7 @@ public class EncryptedKeyAssert extends AbstractObjectAssert<EncryptedKeyAssert,
 	 * @return this assertion for chaining, never {@literal null}
 	 */
 	public EncryptedKeyAssert isDestroyedAt(@Nullable Instant destroyedAt, Duration tolerance) {
-		return assertInstant(EncryptedKey::getDestroyedAt, destroyedAt, tolerance, "key destruction timestamp");
+		return assertInstant(EncryptedKey::destroyedAt, destroyedAt, tolerance, "key destruction timestamp");
 	}
 
 	private ObjectAssert<EncryptedKey> assertThatKey() {

--- a/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/EncryptedKeysetAssert.java
+++ b/konfigyr-crypto-test/src/main/java/com/konfigyr/crypto/test/EncryptedKeysetAssert.java
@@ -59,7 +59,7 @@ public class EncryptedKeysetAssert extends AbstractObjectAssert<EncryptedKeysetA
 	public IterableAssert<EncryptedKey> assertThatKeys() {
 		return assertThatKeyset()
 			.as("encrypted keys")
-			.extracting(EncryptedKeyset::getKeys, InstanceOfAssertFactories.iterable(EncryptedKey.class));
+			.extracting(EncryptedKeyset::keys, InstanceOfAssertFactories.iterable(EncryptedKey.class));
 	}
 
 	/**
@@ -103,7 +103,7 @@ public class EncryptedKeysetAssert extends AbstractObjectAssert<EncryptedKeysetA
 	 */
 	public EncryptedKeysetAssert hasName(@Nullable String name) {
 		assertThatKeyset()
-			.extracting(EncryptedKeyset::getName, InstanceOfAssertFactories.STRING)
+			.extracting(EncryptedKeyset::name, InstanceOfAssertFactories.STRING)
 			.as("keyset name")
 			.isEqualTo(name);
 		return myself;
@@ -117,7 +117,7 @@ public class EncryptedKeysetAssert extends AbstractObjectAssert<EncryptedKeysetA
 	 */
 	public EncryptedKeysetAssert createdByFactory(@Nullable String name) {
 		assertThatKeyset()
-			.extracting(EncryptedKeyset::getFactory, InstanceOfAssertFactories.STRING)
+			.extracting(EncryptedKeyset::factory, InstanceOfAssertFactories.STRING)
 			.as("keyset factory")
 			.isEqualTo(name);
 		return myself;
@@ -141,7 +141,7 @@ public class EncryptedKeysetAssert extends AbstractObjectAssert<EncryptedKeysetA
 	 */
 	public EncryptedKeysetAssert hasPurpose(@Nullable String purpose) {
 		assertThatKeyset()
-			.extracting(EncryptedKeyset::getPurpose, InstanceOfAssertFactories.STRING)
+			.extracting(EncryptedKeyset::purpose, InstanceOfAssertFactories.STRING)
 			.as("keyset purpose")
 			.isEqualTo(purpose);
 		return myself;
@@ -171,11 +171,11 @@ public class EncryptedKeysetAssert extends AbstractObjectAssert<EncryptedKeysetA
 	 */
 	public EncryptedKeysetAssert hasKeyEncryptionKey(@Nullable String provider, @Nullable String id) {
 		assertThatKeyset()
-			.extracting(EncryptedKeyset::getProvider, InstanceOfAssertFactories.STRING)
+			.extracting(EncryptedKeyset::provider, InstanceOfAssertFactories.STRING)
 			.as("KEK provider")
 			.isEqualTo(provider);
 		assertThatKeyset()
-			.extracting(EncryptedKeyset::getKeyEncryptionKey, InstanceOfAssertFactories.STRING)
+			.extracting(EncryptedKeyset::keyEncryptionKey, InstanceOfAssertFactories.STRING)
 			.as("KEK identifier")
 			.isEqualTo(id);
 		return myself;
@@ -204,7 +204,7 @@ public class EncryptedKeysetAssert extends AbstractObjectAssert<EncryptedKeysetA
 	 */
 	public EncryptedKeysetAssert hasRotationInterval(@Nullable Duration interval) {
 		assertThatKeyset()
-			.extracting(EncryptedKeyset::getRotationInterval)
+			.extracting(EncryptedKeyset::rotationInterval)
 			.as("keyset rotation interval")
 			.isEqualTo(interval);
 		return myself;
@@ -219,7 +219,7 @@ public class EncryptedKeysetAssert extends AbstractObjectAssert<EncryptedKeysetA
 	 */
 	public EncryptedKeysetAssert hasDestructionGracePeriod(@Nullable Duration interval) {
 		assertThatKeyset()
-			.extracting(EncryptedKeyset::getDestructionGracePeriod)
+			.extracting(EncryptedKeyset::destructionGracePeriod)
 			.as("keyset destruction grace period")
 			.isEqualTo(interval);
 		return myself;

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkAlgorithm.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkAlgorithm.java
@@ -13,12 +13,12 @@ import com.google.crypto.tink.signature.RsaSsaPssSignKeyManager;
 import com.konfigyr.crypto.Algorithm;
 import com.konfigyr.crypto.KeyType;
 import com.konfigyr.crypto.KeysetPurpose;
-import lombok.EqualsAndHashCode;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.util.Assert;
 
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Collection of {@link Algorithm algorithms} supported by the
@@ -36,7 +36,6 @@ import java.util.List;
  * @see <a href="https://developers.google.com/tink/supported-key-types">Tink - Supported Key Types</a>
  **/
 @NullMarked
-@EqualsAndHashCode(of = "name")
 public final class TinkAlgorithm implements Algorithm {
 
 	/* -------------------------------------------------------------------------
@@ -194,9 +193,16 @@ public final class TinkAlgorithm implements Algorithm {
 		RSA_SSA_PKCS1_3072_SHA256_F4, RSA_SSA_PKCS1_4096_SHA512_F4
 	);
 
+	/** Stable unique algorithm name with {@code "tink:"} prefix. */
 	private final String name;
+
+	/** Intended cryptographic purpose (signing or encryption). */
 	private final KeysetPurpose purpose;
+
+	/** Key material type produced by this algorithm. */
 	private final KeyType type;
+
+	/** Tink key template defining the key parameters for this algorithm. */
 	private final KeyTemplate template;
 
 	/**
@@ -257,6 +263,18 @@ public final class TinkAlgorithm implements Algorithm {
 
 	KeyTemplate template() {
 		return template;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof TinkAlgorithm that)) return false;
+		return Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
 	}
 
 	@Override

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkApplicationContextInitializer.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkApplicationContextInitializer.java
@@ -14,6 +14,12 @@ import org.springframework.context.ConfigurableApplicationContext;
 @NullMarked
 public class TinkApplicationContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
+	/**
+	 * Creates a new {@link TinkApplicationContextInitializer} instance.
+	 */
+	public TinkApplicationContextInitializer() {
+	}
+
 	@Override
 	public void initialize(ConfigurableApplicationContext ctx) {
 		TinkUtils.register();

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkAutoConfiguration.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkAutoConfiguration.java
@@ -22,6 +22,12 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnMissingBean(TinkKeysetFactory.class)
 public class TinkAutoConfiguration {
 
+	/**
+	 * Creates a new {@link TinkAutoConfiguration} instance.
+	 */
+	public TinkAutoConfiguration() {
+	}
+
 	@Bean
 	AlgorithmRegistrar tinkAlgorithmRegistrar() {
 		return registry -> TinkAlgorithm.DEFAULT_ALGORITHMS.forEach(registry::register);

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKey.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKey.java
@@ -7,7 +7,6 @@ import com.konfigyr.crypto.AbstractKey;
 import com.konfigyr.crypto.CryptoException;
 import com.konfigyr.crypto.KeyDefinition;
 import com.konfigyr.crypto.KeyStatus;
-import lombok.Getter;
 import org.jspecify.annotations.NullMarked;
 
 import java.security.GeneralSecurityException;
@@ -19,11 +18,14 @@ import java.security.GeneralSecurityException;
  * @author Vladimir Spasic
  * @since 1.0.0
  **/
-@Getter
 @NullMarked
 class TinkKey extends AbstractKey<TinkAlgorithm> {
 
 	private final com.google.crypto.tink.Key value;
+
+	com.google.crypto.tink.Key getValue() {
+		return value;
+	}
 
 	/**
 	 * Internal constructor used by the {@link AbstractKey} implementations to create the {@link Key} instances.

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeysetFactory.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkKeysetFactory.java
@@ -10,7 +10,6 @@ import com.konfigyr.crypto.*;
 import com.konfigyr.crypto.Key;
 import com.konfigyr.crypto.WrappedKeyMaterial;
 import com.konfigyr.io.ByteArray;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.util.Assert;
 
@@ -36,12 +35,20 @@ import java.util.List;
  * @see TinkKeyset
  **/
 @NullMarked
-@RequiredArgsConstructor
 public class TinkKeysetFactory implements KeysetFactory {
 
 	static final String NAME = "tink";
 
 	private final AlgorithmRegistry registry;
+
+	/**
+	 * Creates a new {@link TinkKeysetFactory} that resolves algorithms from the given registry.
+	 *
+	 * @param registry the algorithm registry used to look up {@link TinkAlgorithm} instances, can't be {@literal null}
+	 */
+	public TinkKeysetFactory(AlgorithmRegistry registry) {
+		this.registry = registry;
+	}
 
 	@Override
 	public String getName() {
@@ -99,17 +106,17 @@ public class TinkKeysetFactory implements KeysetFactory {
 			.keyEncryptionKey(kek);
 
 		for (EncryptedKey encrypted : encryptedKeyset) {
-			if (encrypted.getData() == null) {
+			if (encrypted.data() == null) {
 				continue;
 			}
 
-			final ByteArray unwrapped = kek.unwrap(encrypted.getData());
+			final ByteArray unwrapped = kek.unwrap(encrypted.data());
 			final KeyData data;
 
 			try {
 				data = KeyData.parseFrom(unwrapped.array());
 			} catch (InvalidProtocolBufferException ex) {
-				throw new CryptoException.UnwrappingException(encryptedKeyset.getName(), kek, ex);
+				throw new CryptoException.UnwrappingException(encryptedKeyset.name(), kek, ex);
 			}
 
 			final com.google.crypto.tink.Key key;
@@ -120,27 +127,27 @@ public class TinkKeysetFactory implements KeysetFactory {
 					data.getValue(),
 					ProtoConversions.fromProto(data.getKeyMaterialType()),
 					ProtoKeySerialization.OutputPrefixType.TINK,
-					Integer.parseInt(encrypted.getId())
+					Integer.parseInt(encrypted.id())
 				);
 
 				key = MutableSerializationRegistry.globalInstance()
 					.parseKey(serialization, InsecureSecretKeyAccess.get());
 			} catch (Exception e) {
-				throw new CryptoException.UnwrappingException(encryptedKeyset.getName(), kek, e);
+				throw new CryptoException.UnwrappingException(encryptedKeyset.name(), kek, e);
 			}
 
-			final TinkAlgorithm algorithm = (TinkAlgorithm) registry.resolve(encrypted.getAlgorithm());
+			final TinkAlgorithm algorithm = (TinkAlgorithm) registry.resolve(encrypted.algorithm());
 
 			builder.key(new TinkKey.Builder(key)
-				.id(encrypted.getId())
-				.status(encrypted.getStatus())
+				.id(encrypted.id())
+				.status(encrypted.status())
 				.algorithm(algorithm)
-				.primary(encrypted.isPrimary())
-				.createdAt(encrypted.getCreatedAt())
-				.initializedAt(encrypted.getInitializedAt())
-				.expiresAt(encrypted.getExpiresAt())
-				.destructionScheduledAt(encrypted.getDestructionScheduledAt())
-				.destroyedAt(encrypted.getDestroyedAt())
+				.primary(encrypted.primary())
+				.createdAt(encrypted.createdAt())
+				.initializedAt(encrypted.initializedAt())
+				.expiresAt(encrypted.expiresAt())
+				.destructionScheduledAt(encrypted.destructionScheduledAt())
+				.destroyedAt(encrypted.destroyedAt())
 				.build()
 			);
 		}

--- a/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkUtils.java
+++ b/konfigyr-crypto-tink/src/main/java/com/konfigyr/crypto/tink/TinkUtils.java
@@ -13,16 +13,16 @@ import com.google.crypto.tink.internal.Util;
 import com.google.crypto.tink.signature.SignatureConfig;
 import com.google.crypto.tink.signature.SignaturePrivateKey;
 import com.google.crypto.tink.util.Bytes;
-import lombok.experimental.UtilityClass;
-
 import java.security.GeneralSecurityException;
 
 /**
  * @author Vladimir Spasic
  * @since 1.0.0
  **/
-@UtilityClass
-class TinkUtils {
+final class TinkUtils {
+
+	private TinkUtils() {
+	}
 
 	static void register() {
 		try {

--- a/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkAlgorithmTest.java
+++ b/konfigyr-crypto-tink/src/test/java/com/konfigyr/crypto/tink/TinkAlgorithmTest.java
@@ -1,0 +1,46 @@
+package com.konfigyr.crypto.tink;
+
+import com.google.crypto.tink.aead.AesGcmKeyManager;
+import com.konfigyr.crypto.KeyType;
+import com.konfigyr.crypto.KeysetPurpose;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class TinkAlgorithmTest {
+
+	@Test
+	@DisplayName("should fail to create algorithm without a valid `tink:` prefix")
+	void shouldAssertTinkPrefix() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new TinkAlgorithm(
+			"AES128_GCM", KeysetPurpose.ENCRYPTION, KeyType.OCTET, AesGcmKeyManager.aes128GcmTemplate()
+		)).withMessage("Tink algorithm names must start with 'tink:' prefix");
+	}
+
+	@Test
+	@DisplayName("should consider two algorithms with the same name equal")
+	void shouldBeEqualByName() {
+		final var algorithm = new TinkAlgorithm(
+			"tink:AES128_GCM", KeysetPurpose.ENCRYPTION, KeyType.OCTET, AesGcmKeyManager.aes128GcmTemplate()
+		);
+
+		assertThat(algorithm)
+			.isEqualTo(TinkAlgorithm.AES128_GCM)
+			.hasSameHashCodeAs(TinkAlgorithm.AES128_GCM);
+
+		assertThat(algorithm)
+			.isNotEqualTo(TinkAlgorithm.AES256_GCM);
+	}
+
+	@Test
+	@DisplayName("should produce a non-blank toString")
+	void shouldProduceNonBlankToString() {
+		assertThat(TinkAlgorithm.AES128_GCM)
+			.hasToString("tink:AES128_GCM");
+		assertThat(TinkAlgorithm.AES256_GCM)
+			.hasToString("tink:AES256_GCM");
+	}
+
+}


### PR DESCRIPTION
Completes all pre-release tasks required to ship the stable 1.0.0 release.

#### Transaction rollback coverage (konfigyr-crypto-jdbc)
- Added two integration tests to `JdbcKeysetRepositoryTest` verifying that `create()` rolls back the `KEYSETS` row when `insertKeys()` throws, and that `update()` rolls back the `KEYSETS` row when key sync fails mid-diff.

#### API typo fix (konfigyr-crypto-api)
- Renamed `RepostoryKeysetStore.java` → `RepositoryKeysetStore.java` and updated all Javadoc `@see/{@link}` tags and the `build()` factory method in `KeysetStore`.

#### Lombok removal (all modules)
- Replaced all Lombok annotations (`@Data`, `@Getter`, `@Setter`, `@RequiredArgsConstructor`, `@EqualsAndHashCode`, `@UtilityClass`) with explicit constructors, getters, and equals()/hashCode() implementations across all six modules.
- `JdbcKeysetProperties` converted from a `@Data` class to a Java record using `@DefaultValue` for Spring Boot configuration binding.
- `TinkUtils` marked final with an explicit private constructor (replaces `@UtilityClass`).

#### Javadoc completion (all modules)
- Added missing class-level and method-level Javadoc to all public types and methods on `AbstractKey`, `AbstractKeyset`, `AbstractKeyEncryptionKey`, `WrappedKeyMaterial`, `JdbcKeysetRepository`, and all affected configuration classes.
- Fixed pre-existing use of default constructor Javadoc warnings on `TinkApplicationContextInitializer`, `TinkAutoConfiguration`, `JoseAutoConfiguration`, and `AbstractKeysetFactoryTest` by adding explicit documented constructors.
- Fixed pre-existing no comment Javadoc warnings on private instance fields in `JoseAlgorithm` and `TinkAlgorithm`.
- Fixed typo "Keyseet" → "Keyset" in `JdbcKeysetDataSourceScriptDatabaseInitializer` Javadoc.